### PR TITLE
separate `execute` and `subscribe`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@
  * @packageDocumentation
  */
 
-export { stitch } from './stitch/stitch.js';
+export { execute, subscribe } from './stitch/stitch.js';

--- a/src/stitch/Stitcher.ts
+++ b/src/stitch/Stitcher.ts
@@ -20,11 +20,7 @@ import { deepAssign } from '../utilities/deepAssign.js';
 export type Executor = (args: {
   document: DocumentNode;
   variables?: { readonly [variable: string]: unknown } | undefined;
-}) => PromiseOrValue<
-  | ExecutionResult
-  | AsyncIterableIterator<ExecutionResult>
-  | ExperimentalIncrementalExecutionResults
->;
+}) => PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults>;
 
 export interface ExecutionContext {
   schema: GraphQLSchema;

--- a/src/stitch/__tests__/graphql-js/execute.ts
+++ b/src/stitch/__tests__/graphql-js/execute.ts
@@ -11,7 +11,7 @@ import type { PromiseOrValue } from '../../../types/PromiseOrValue.js';
 import { isAsyncIterable } from '../../../predicates/isAsyncIterable.js';
 import { isPromise } from '../../../predicates/isPromise.js';
 
-import { stitch } from '../../stitch.js';
+import { execute as gatewayExecute } from '../../stitch.js';
 
 export function executeWithGraphQL(
   args: ExecutionArgs,
@@ -20,7 +20,7 @@ export function executeWithGraphQL(
   | AsyncIterableIterator<ExecutionResult>
   | ExperimentalIncrementalExecutionResults
 > {
-  return stitch({
+  return gatewayExecute({
     ...args,
     operationName: args.operationName ?? undefined,
     variableValues: args.variableValues ?? undefined,

--- a/src/stitch/__tests__/graphql-js/subscribe.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe.ts
@@ -1,25 +1,32 @@
 import type { ExecutionArgs, ExecutionResult } from 'graphql';
-import { subscribe as graphQLSubscribe } from 'graphql';
+import {
+  execute as graphQLExecute,
+  subscribe as graphQLSubscribe,
+} from 'graphql';
 
 import type { PromiseOrValue } from '../../../types/PromiseOrValue.js';
 
-import { stitch } from '../../stitch.js';
+import { subscribe as gatwaySubscribe } from '../../stitch.js';
 
 export function subscribeWithGraphQL(
   args: ExecutionArgs,
 ): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
   // casting as subscriptions cannot return incremental values
-  return stitch({
+  return gatwaySubscribe({
     ...args,
     operationName: args.operationName ?? undefined,
     variableValues: args.variableValues ?? undefined,
     executor: ({ document, variables }) =>
+      graphQLExecute({
+        ...args,
+        document,
+        variableValues: variables,
+      }),
+    subscriber: ({ document, variables }) =>
       graphQLSubscribe({
         ...args,
         document,
         variableValues: variables,
       }),
-  }) as PromiseOrValue<
-    ExecutionResult | AsyncIterableIterator<ExecutionResult>
-  >;
+  });
 }

--- a/src/stitch/__tests__/graphql-js/subscribe.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe.ts
@@ -6,13 +6,13 @@ import {
 
 import type { PromiseOrValue } from '../../../types/PromiseOrValue.js';
 
-import { subscribe as gatwaySubscribe } from '../../stitch.js';
+import { subscribe as gatewaySubscribe } from '../../stitch.js';
 
 export function subscribeWithGraphQL(
   args: ExecutionArgs,
 ): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
   // casting as subscriptions cannot return incremental values
-  return gatwaySubscribe({
+  return gatewaySubscribe({
     ...args,
     operationName: args.operationName ?? undefined,
     variableValues: args.variableValues ?? undefined,

--- a/src/stitch/stitch.ts
+++ b/src/stitch/stitch.ts
@@ -36,13 +36,9 @@ export interface ExecutionArgs {
   executor: Executor;
 }
 
-export function stitch(
+export function execute(
   args: ExecutionArgs,
-): PromiseOrValue<
-  | ExecutionResult
-  | AsyncIterableIterator<ExecutionResult>
-  | ExperimentalIncrementalExecutionResults
-> {
+): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext(args);
@@ -140,11 +136,7 @@ function buildExecutionContext(
 
 function delegate(
   exeContext: ExecutionContext,
-): PromiseOrValue<
-  | ExecutionResult
-  | AsyncIterableIterator<ExecutionResult>
-  | ExperimentalIncrementalExecutionResults
-> {
+): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
   const rootType = exeContext.schema.getRootType(
     exeContext.operation.operation,
   );
@@ -155,11 +147,6 @@ function delegate(
       { nodes: exeContext.operation },
     );
 
-    const { operation } = exeContext;
-    // execution is not considered to have begun for subscriptions until the source stream is created
-    if (operation.operation === OperationTypeNode.SUBSCRIPTION) {
-      return { errors: [error] };
-    }
     return { data: null, errors: [error] };
   }
 
@@ -182,32 +169,9 @@ function handleSingleResult<
   return new Stitcher(exeContext, result).stitch();
 }
 
-// executions and mutations can return incremental results
-// subscriptions on successful creation will return multiple payloads
 function handlePossibleMultiPartResult<
-  T extends
-    | ExecutionResult
-    | AsyncIterableIterator<ExecutionResult>
-    | ExperimentalIncrementalExecutionResults,
+  T extends ExecutionResult | ExperimentalIncrementalExecutionResults,
 >(exeContext: ExecutionContext, result: T): PromiseOrValue<T> {
-  if (isAsyncIterable(result)) {
-    return mapAsyncIterable<ExecutionResult, ExecutionResult>(
-      result,
-      (payload) => handleSingleResult(exeContext, payload),
-    ) as T;
-  }
-
-  if (exeContext.operation.operation === OperationTypeNode.SUBSCRIPTION) {
-    // subscriptions cannot return a result containing an incremental stream
-    invariant(!('initialResult' in result));
-    // execution is not considered to have begun for subscriptions until the source stream is created
-    if (result.data == null && result.errors) {
-      return { errors: result.errors } as T;
-    }
-    // Not reached.
-    return result;
-  }
-
   if ('initialResult' in result) {
     return {
       initialResult: handleSingleResult(exeContext, result.initialResult),
@@ -241,4 +205,77 @@ function handlePossibleMultiPartResult<
   }
 
   return handleSingleResult(exeContext, result) as T;
+}
+
+export type Subscriber = (args: {
+  document: DocumentNode;
+  variables?: { readonly [variable: string]: unknown } | undefined;
+}) => PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>>;
+
+export interface SubscriptionArgs extends ExecutionArgs {
+  subscriber: Subscriber;
+}
+
+export function subscribe(
+  args: SubscriptionArgs,
+): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return { errors: exeContext };
+  }
+
+  invariant(exeContext.operation.operation === OperationTypeNode.SUBSCRIPTION);
+
+  const result = delegateSubscription(exeContext, args.subscriber);
+
+  if (isPromise(result)) {
+    return result.then((resolved) =>
+      handlePossibleStream(exeContext, resolved),
+    );
+  }
+  return handlePossibleStream(exeContext, result);
+}
+
+function delegateSubscription(
+  exeContext: ExecutionContext,
+  subscriber: Subscriber,
+): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
+  const rootType = exeContext.schema.getRootType(
+    exeContext.operation.operation,
+  );
+
+  if (rootType == null) {
+    const error = new GraphQLError(
+      'Schema is not configured to execute subscription operation.',
+      { nodes: exeContext.operation },
+    );
+
+    return { errors: [error] };
+  }
+
+  const { operation, fragments, rawVariableValues } = exeContext;
+
+  const document = createRequest(operation, fragments);
+
+  return subscriber({
+    document,
+    variables: rawVariableValues,
+  });
+}
+
+function handlePossibleStream<
+  T extends ExecutionResult | AsyncIterableIterator<ExecutionResult>,
+>(exeContext: ExecutionContext, result: T): PromiseOrValue<T> {
+  if (isAsyncIterable(result)) {
+    return mapAsyncIterable<ExecutionResult, ExecutionResult>(
+      result,
+      (payload) => handleSingleResult(exeContext, payload),
+    ) as T;
+  }
+
+  return result;
 }


### PR DESCRIPTION
This PR separates the `execute` and `subscribe` functions as well as the `Executor` and `Subscriber` types.

It appears that incremental results returned by `execute` or an `Executor` will not actually match that of `subscribe` or a `Subscriber`.

The stitcher will only require use of an `Executor`, not a `Subscriber`. We can separate the functions and types a this point for simplicity.