### PR TITLE
implement root field routing logic

### DIFF
--- a/src/stitch/__tests__/SuperSchema-test.ts
+++ b/src/stitch/__tests__/SuperSchema-test.ts
@@ -49,9 +49,9 @@ describe('SuperSchema', () => {
       }
     `);
 
-    const someSubchema = getSubschema(someSchema);
-    const anotherSubchema = getSubschema(anotherSchema);
-    const superSchema = new SuperSchema([someSubchema, anotherSubchema]);
+    const someSubschema = getSubschema(someSchema);
+    const anotherSubschema = getSubschema(anotherSchema);
+    const superSchema = new SuperSchema([someSubschema, anotherSubschema]);
 
     const queryType = superSchema.getRootType(OperationTypeNode.QUERY);
     expect(queryType).to.deep.include({
@@ -86,9 +86,9 @@ describe('SuperSchema', () => {
       }
     `);
 
-    const someSubchema = getSubschema(someSchema);
-    const anotherSubchema = getSubschema(anotherSchema);
-    const superSchema = new SuperSchema([someSubchema, anotherSubchema]);
+    const someSubschema = getSubschema(someSchema);
+    const anotherSubschema = getSubschema(anotherSchema);
+    const superSchema = new SuperSchema([someSubschema, anotherSubschema]);
 
     const someObjectType = superSchema.getType('SomeObject') as
       | GraphQLObjectType
@@ -125,9 +125,9 @@ describe('SuperSchema', () => {
       }
     `);
 
-    const someSubchema = getSubschema(someSchema);
-    const anotherSubchema = getSubschema(anotherSchema);
-    const superSchema = new SuperSchema([someSubchema, anotherSubchema]);
+    const someSubschema = getSubschema(someSchema);
+    const anotherSubschema = getSubschema(anotherSchema);
+    const superSchema = new SuperSchema([someSubschema, anotherSubschema]);
 
     const operation = parse(
       `{
@@ -143,7 +143,7 @@ describe('SuperSchema', () => {
       {},
     );
 
-    const someSchemaOperation = splitDocuments.get(someSubchema);
+    const someSchemaOperation = splitDocuments.get(someSubschema);
     expect(someSchemaOperation).to.deep.equal(
       parse(
         `{
@@ -153,7 +153,7 @@ describe('SuperSchema', () => {
       ),
     );
 
-    const anotherSchemaOperation = splitDocuments.get(anotherSubchema);
+    const anotherSchemaOperation = splitDocuments.get(anotherSubschema);
     expect(anotherSchemaOperation).to.deep.equal(
       parse(
         `{
@@ -185,9 +185,9 @@ describe('SuperSchema', () => {
       }
     `);
 
-    const someSubchema = getSubschema(someSchema);
-    const anotherSubchema = getSubschema(anotherSchema);
-    const superSchema = new SuperSchema([someSubchema, anotherSubchema]);
+    const someSubschema = getSubschema(someSchema);
+    const anotherSubschema = getSubschema(anotherSchema);
+    const superSchema = new SuperSchema([someSubschema, anotherSubschema]);
 
     const operation = parse(
       `{
@@ -217,7 +217,7 @@ describe('SuperSchema', () => {
       ),
     );
 
-    const someSchemaOperation = splitDocuments.get(someSubchema);
+    const someSchemaOperation = splitDocuments.get(someSubschema);
     expect(someSchemaOperation).to.deep.equal(
       parse(
         `{
@@ -227,7 +227,7 @@ describe('SuperSchema', () => {
       ),
     );
 
-    const anotherSchemaOperation = splitDocuments.get(anotherSubchema);
+    const anotherSchemaOperation = splitDocuments.get(anotherSubschema);
     expect(anotherSchemaOperation).to.deep.equal(
       parse(
         `{

--- a/src/stitch/__tests__/graphql-js/execute.ts
+++ b/src/stitch/__tests__/graphql-js/execute.ts
@@ -22,15 +22,20 @@ export function executeWithGraphQL(
 > {
   return gatewayExecute({
     ...args,
-    schemas: [args.schema],
+    subschemas: [
+      {
+        schema: args.schema,
+        executor: ({ document, variables }) =>
+          graphqlExecute({
+            ...args,
+            schema: args.schema,
+            document,
+            variableValues: variables,
+          }),
+      },
+    ],
     operationName: args.operationName ?? undefined,
     variableValues: args.variableValues ?? undefined,
-    executor: ({ document, variables }) =>
-      graphqlExecute({
-        ...args,
-        document,
-        variableValues: variables,
-      }),
   });
 }
 

--- a/src/stitch/__tests__/graphql-js/subscribe-test.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe-test.ts
@@ -400,11 +400,21 @@ describe('Subscription Initialization Phase', () => {
     const document = parse('subscription { unknownField }');
 
     const result = subscribe({ schema, document });
+    /*
     expectJSON(result).toDeepEqual({
       errors: [
         {
           message: 'The subscription field "unknownField" is not defined.',
           locations: [{ line: 1, column: 16 }],
+        },
+      ],
+    });
+    */
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'Could not route subscription.',
+          locations: [{ line: 1, column: 1 }],
         },
       ],
     });

--- a/src/stitch/__tests__/graphql-js/subscribe.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe.ts
@@ -14,20 +14,24 @@ export function subscribeWithGraphQL(
   // casting as subscriptions cannot return incremental values
   return gatewaySubscribe({
     ...args,
-    schemas: [args.schema],
+    subschemas: [
+      {
+        schema: args.schema,
+        executor: ({ document, variables }) =>
+          graphQLExecute({
+            ...args,
+            document,
+            variableValues: variables,
+          }),
+        subscriber: ({ document, variables }) =>
+          graphQLSubscribe({
+            ...args,
+            document,
+            variableValues: variables,
+          }),
+      },
+    ],
     operationName: args.operationName ?? undefined,
     variableValues: args.variableValues ?? undefined,
-    executor: ({ document, variables }) =>
-      graphQLExecute({
-        ...args,
-        document,
-        variableValues: variables,
-      }),
-    subscriber: ({ document, variables }) =>
-      graphQLSubscribe({
-        ...args,
-        document,
-        variableValues: variables,
-      }),
   });
 }

--- a/src/stitch/subscribe.ts
+++ b/src/stitch/subscribe.ts
@@ -43,7 +43,7 @@ export function subscribe(
 
   const documents = exeContext.superSchema.splitDocument(
     operation,
-    fragments, 
+    fragments,
     fragmentMap,
   );
 

--- a/src/utilities/__tests__/inlineRootFragments-test.ts
+++ b/src/utilities/__tests__/inlineRootFragments-test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import type { FragmentDefinitionNode, OperationDefinitionNode } from 'graphql';
+import { parse } from 'graphql';
+import { describe, it } from 'mocha';
+
+import { inlineRootFragments } from '../inlineRootFragments.js';
+
+describe('inlineRootFragments', () => {
+  it('works', () => {
+    const document = parse(
+      `
+      {
+        someField
+        ... {
+          anotherField
+        }
+        ...SomeFragment
+      }
+
+      fragment SomeFragment on Query {
+        fragmentField
+      }
+      `,
+      { noLocation: true },
+    );
+
+    const operation = document.definitions[0] as OperationDefinitionNode;
+    const fragmentMap = {
+      SomeFragment: document.definitions[1] as FragmentDefinitionNode,
+    };
+
+    const selectionSet = inlineRootFragments(
+      operation.selectionSet,
+      fragmentMap,
+    );
+
+    const expectedSelectionSet = (
+      parse(
+        `
+        {
+          someField
+          ... {
+            anotherField
+          }
+          ... on Query {
+            fragmentField
+          }
+        }
+        `,
+        { noLocation: true },
+      ).definitions[0] as OperationDefinitionNode
+    ).selectionSet;
+
+    expect(selectionSet).to.deep.equal(expectedSelectionSet);
+  });
+});

--- a/src/utilities/inlineRootFragments.ts
+++ b/src/utilities/inlineRootFragments.ts
@@ -1,0 +1,57 @@
+import type {
+  FragmentDefinitionNode,
+  SelectionNode,
+  SelectionSetNode,
+} from 'graphql';
+import { Kind } from 'graphql';
+
+import type { ObjMap } from '../types/ObjMap';
+
+export function inlineRootFragments(
+  selectionSet: SelectionSetNode,
+  fragmentMap: ObjMap<FragmentDefinitionNode>,
+  visitedFragments: Set<string> = new Set(),
+): SelectionSetNode {
+  const selections: Array<SelectionNode> = [];
+  for (const selection of selectionSet.selections) {
+    switch (selection.kind) {
+      case Kind.FIELD:
+        selections.push(selection);
+        break;
+      case Kind.INLINE_FRAGMENT:
+        selections.push({
+          ...selection,
+          selectionSet: inlineRootFragments(
+            selection.selectionSet,
+            fragmentMap,
+            visitedFragments,
+          ),
+        });
+        break;
+      case Kind.FRAGMENT_SPREAD: {
+        if (visitedFragments.has(selection.name.value)) {
+          continue;
+        }
+        visitedFragments.add(selection.name.value);
+        const fragment = fragmentMap[selection.name.value];
+        if (fragment) {
+          selections.push({
+            kind: Kind.INLINE_FRAGMENT,
+            directives: selection.directives,
+            typeCondition: fragment.typeCondition,
+            selectionSet: inlineRootFragments(
+              fragment.selectionSet,
+              fragmentMap,
+              visitedFragments,
+            ),
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    kind: Kind.SELECTION_SET,
+    selections,
+  };
+}


### PR DESCRIPTION
This ended up being a significant rewrite of the rudiementary routing structure.

Required:

-- requires introducing Subschemas interface with schemas and their executors and subscribers

-- fixing splitOperation to operate on fragments spreads as well, basically we just convert to inline fragments

-- inlining utility introduced separately

-- also took opportunity to rework splitOperation into splitDocument