### PR TITLE
use AsyncGenerator signature instead of AsyncIterableIterator

### DIFF
--- a/src/stitch/SuperSchema.ts
+++ b/src/stitch/SuperSchema.ts
@@ -92,7 +92,9 @@ export type Executor = (args: {
 export type Subscriber = (args: {
   document: DocumentNode;
   variables?: { readonly [variable: string]: unknown } | undefined;
-}) => PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>>;
+}) => PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+>;
 
 export interface Subschema {
   schema: GraphQLSchema;

--- a/src/stitch/__tests__/graphql-js/execute.ts
+++ b/src/stitch/__tests__/graphql-js/execute.ts
@@ -17,7 +17,7 @@ export function executeWithGraphQL(
   args: ExecutionArgs,
 ): PromiseOrValue<
   | ExecutionResult
-  | AsyncIterableIterator<ExecutionResult>
+  | AsyncGenerator<ExecutionResult, void, void>
   | ExperimentalIncrementalExecutionResults
 > {
   return gatewayExecute({

--- a/src/stitch/__tests__/graphql-js/lists-test.ts
+++ b/src/stitch/__tests__/graphql-js/lists-test.ts
@@ -94,7 +94,7 @@ describe('Execute: Accepts async iterables as list value', () => {
     resolve: GraphQLFieldResolver<{ index: number }, unknown>,
   ): PromiseOrValue<
     | ExecutionResult
-    | AsyncIterableIterator<ExecutionResult>
+    | AsyncGenerator<ExecutionResult, void, void>
     | ExperimentalIncrementalExecutionResults
   > {
     const schema = new GraphQLSchema({

--- a/src/stitch/__tests__/graphql-js/nonnull-test.ts
+++ b/src/stitch/__tests__/graphql-js/nonnull-test.ts
@@ -119,7 +119,7 @@ function executeQuery(
   rootValue: unknown,
 ): PromiseOrValue<
   | ExecutionResult
-  | AsyncIterableIterator<ExecutionResult>
+  | AsyncGenerator<ExecutionResult, void, void>
   | ExperimentalIncrementalExecutionResults
 > {
   return execute({ schema, document: parse(query), rootValue });

--- a/src/stitch/__tests__/graphql-js/subscribe-test.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe-test.ts
@@ -161,7 +161,9 @@ const DummyQueryType = new GraphQLObjectType({
 
 function subscribeWithBadFn(
   subscribeFn: () => unknown,
-): PromiseOrValue<ExecutionResult | AsyncIterableIterator<unknown>> {
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
   const schema = new GraphQLSchema({
     query: DummyQueryType,
     subscription: new GraphQLObjectType({
@@ -608,7 +610,7 @@ describe('Subscription Publish Phase', () => {
         },
       },
     });
-    expect(await subscription.return?.()).to.deep.equal({
+    expect(await subscription.return()).to.deep.equal({
       done: true,
       value: undefined,
     });
@@ -681,7 +683,7 @@ describe('Subscription Publish Phase', () => {
     });
 
     // The client decides to disconnect.
-    expect(await subscription.return?.()).to.deep.equal({
+    expect(await subscription.return()).to.deep.equal({
       done: true,
       value: undefined,
     });
@@ -754,7 +756,7 @@ describe('Subscription Publish Phase', () => {
     // The next waited on payload will have a value.
     expectJSON(await subscription.next()).toDeepEqual(errorPayload);
 
-    expectJSON(await subscription.return?.()).toDeepEqual({
+    expectJSON(await subscription.return()).toDeepEqual({
       done: true,
       value: undefined,
     });
@@ -839,7 +841,7 @@ describe('Subscription Publish Phase', () => {
       },
     });
 
-    expectJSON(await subscription.return?.()).toDeepEqual({
+    expectJSON(await subscription.return()).toDeepEqual({
       done: true,
       value: undefined,
     });
@@ -953,7 +955,7 @@ describe('Subscription Publish Phase', () => {
     });
 
     payload = subscription.next();
-    await subscription.return?.();
+    await subscription.return();
 
     // A new email arrives!
     expect(
@@ -1019,7 +1021,7 @@ describe('Subscription Publish Phase', () => {
      * `.throw()` until after a payload is available.
      *
      * This change should have marginal effect on client use of the API, as clients should not be
-     * calling `.throw()` on the AsyncIterableIterator returned by our executor.
+     * calling `.throw()` on the AsyncGenerator returned by our executor.
      **/
 
     // payload = subscription.next();

--- a/src/stitch/__tests__/graphql-js/subscribe.ts
+++ b/src/stitch/__tests__/graphql-js/subscribe.ts
@@ -10,7 +10,9 @@ import { subscribe as gatewaySubscribe } from '../../subscribe.js';
 
 export function subscribeWithGraphQL(
   args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
   // casting as subscriptions cannot return incremental values
   return gatewaySubscribe({
     ...args,

--- a/src/stitch/execute.ts
+++ b/src/stitch/execute.ts
@@ -104,7 +104,7 @@ function handlePossibleMultiPartResults<
     ExecutionResult | InitialIncrementalExecutionResult
   > = [];
   const asyncIterators: Array<
-    AsyncIterableIterator<SubsequentIncrementalExecutionResult>
+    AsyncGenerator<SubsequentIncrementalExecutionResult>
   > = [];
 
   for (const result of results) {
@@ -164,9 +164,7 @@ function mergeInitialResults(
 }
 
 function mergeSubsequentResults(
-  asyncIterators: Array<
-    AsyncIterableIterator<SubsequentIncrementalExecutionResult>
-  >,
+  asyncIterators: Array<AsyncGenerator<SubsequentIncrementalExecutionResult>>,
 ): AsyncGenerator<SubsequentIncrementalExecutionResult> {
   const mergedAsyncIterator = Repeater.merge(asyncIterators);
 
@@ -184,5 +182,5 @@ function mergeSubsequentResults(
       };
     }
     return payload;
-  }) as AsyncGenerator<SubsequentIncrementalExecutionResult>;
+  });
 }

--- a/src/stitch/subscribe.ts
+++ b/src/stitch/subscribe.ts
@@ -16,7 +16,9 @@ import type { Subschema } from './SuperSchema.js';
 
 export function subscribe(
   args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult | AsyncIterableIterator<ExecutionResult>> {
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext(args);
@@ -81,13 +83,10 @@ export function subscribe(
 }
 
 function handlePossibleStream<
-  T extends ExecutionResult | AsyncIterableIterator<ExecutionResult>,
+  T extends ExecutionResult | AsyncGenerator<ExecutionResult, void, void>,
 >(result: T): PromiseOrValue<T> {
   if (isAsyncIterable(result)) {
-    return mapAsyncIterable<ExecutionResult, ExecutionResult>(
-      result,
-      (payload) => payload,
-    ) as T;
+    return mapAsyncIterable(result, (payload) => payload) as T;
   }
 
   return result;


### PR DESCRIPTION
previously, we used AsyncIterableIterator because graphql-js actually returns an object with the AsyncGenerator signature that isn't actually a generator, i.e. does not resolve all calls to `.next()`, `.throw()`, and `.return()` in call order.

Now that this library uses a Repeater-based implementation of mapAsyncIterable, we always actually return a generator, so we can be less strict about this distinction.