### PR TITLE
add PlanResult abstraction

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -646,7 +646,8 @@ overrides:
   - files: 'src/**/__*__/**'
     rules:
       internal-rules/require-to-string-tag: off
-      node/no-unpublished-import: [error, { allowModules: ['chai', 'mocha'] }]
+      node/no-unpublished-import:
+        [error, { allowModules: ['chai', 'mocha', 'sinon'] }]
       import/no-deprecated: off
       import/no-restricted-paths: off
       import/no-extraneous-dependencies: [error, { devDependencies: true }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/mocha": "10.0.0",
         "@types/node": "18.11.9",
         "@types/prettier": "2.7.1",
+        "@types/sinon": "^10.0.13",
         "@typescript-eslint/eslint-plugin": "5.43.0",
         "@typescript-eslint/parser": "5.43.0",
         "c8": "7.12.0",
@@ -30,6 +31,7 @@
         "eslint-plugin-simple-import-sort": "8.0.0",
         "mocha": "10.1.0",
         "prettier": "2.7.1",
+        "sinon": "^15.0.1",
         "ts-node": "10.9.1",
         "typescript": "4.9.3"
       },
@@ -632,6 +634,41 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -708,6 +745,21 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3136,6 +3188,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3248,6 +3306,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3281,6 +3345,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3551,6 +3621,19 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -3751,6 +3834,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4107,6 +4199,24 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -5262,6 +5372,41 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
     },
+    "@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -5338,6 +5483,21 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -7092,6 +7252,12 @@
         "call-bind": "^1.0.2"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7183,6 +7349,12 @@
         "universalify": "^2.0.0"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7207,6 +7379,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -7417,6 +7595,19 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -7552,6 +7743,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -7774,6 +7974,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/mocha": "10.0.0",
     "@types/node": "18.11.9",
     "@types/prettier": "2.7.1",
+    "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "5.43.0",
     "@typescript-eslint/parser": "5.43.0",
     "c8": "7.12.0",
@@ -72,6 +73,7 @@
     "eslint-plugin-simple-import-sort": "8.0.0",
     "mocha": "10.1.0",
     "prettier": "2.7.1",
+    "sinon": "^15.0.1",
     "ts-node": "10.9.1",
     "typescript": "4.9.3"
   },

--- a/src/stitch/PlanResult.ts
+++ b/src/stitch/PlanResult.ts
@@ -1,0 +1,244 @@
+import type {
+  DocumentNode,
+  ExecutionResult,
+  ExperimentalIncrementalExecutionResults,
+  FragmentDefinitionNode,
+  InitialIncrementalExecutionResult,
+  OperationDefinitionNode,
+  SubsequentIncrementalExecutionResult,
+} from 'graphql';
+import { GraphQLError, Kind } from 'graphql';
+import type { ObjMap } from 'graphql/jsutils/ObjMap.js';
+
+import type { PromiseOrValue } from '../types/PromiseOrValue.js';
+import type { SimpleAsyncGenerator } from '../types/SimpleAsyncGenerator.js';
+
+import { isAsyncIterable } from '../predicates/isAsyncIterable.js';
+import { isPromise } from '../predicates/isPromise.js';
+import { Consolidator } from '../utilities/Consolidator.js';
+
+import { mapAsyncIterable } from './mapAsyncIterable.js';
+import type { Plan } from './Plan.js';
+
+interface PromiseContext {
+  promiseCount: number;
+  promise: Promise<void>;
+  trigger: () => void;
+}
+
+/**
+ * @internal
+ */
+export class PlanResult {
+  plan: Plan;
+  operation: OperationDefinitionNode;
+  fragments: ReadonlyArray<FragmentDefinitionNode>;
+  rawVariableValues:
+    | {
+        readonly [variable: string]: unknown;
+      }
+    | undefined;
+
+  _data: ObjMap<unknown>;
+  _nullData: boolean;
+  _errors: Array<GraphQLError>;
+  _consolidator: Consolidator<SubsequentIncrementalExecutionResult> | undefined;
+
+  _promiseContext: PromiseContext | undefined;
+
+  constructor(
+    plan: Plan,
+    operation: OperationDefinitionNode,
+    fragments: ReadonlyArray<FragmentDefinitionNode>,
+    rawVariableValues:
+      | {
+          readonly [variable: string]: unknown;
+        }
+      | undefined,
+  ) {
+    this.plan = plan;
+    this.operation = operation;
+    this.fragments = fragments;
+    this.rawVariableValues = rawVariableValues;
+    this._data = Object.create(null);
+    this._nullData = false;
+    this._errors = [];
+  }
+
+  execute(): PromiseOrValue<
+    ExecutionResult | ExperimentalIncrementalExecutionResults
+  > {
+    for (const [subschema, subschemaSelections] of this.plan.map.entries()) {
+      const document: DocumentNode = {
+        kind: Kind.DOCUMENT,
+        definitions: [
+          {
+            ...this.operation,
+            selectionSet: {
+              kind: Kind.SELECTION_SET,
+              selections: subschemaSelections,
+            },
+          },
+          ...this.fragments,
+        ],
+      };
+
+      const result = subschema.executor({
+        document,
+        variables: this.rawVariableValues,
+      });
+
+      if (isPromise(result)) {
+        if (this._promiseContext) {
+          this._promiseContext.promiseCount++;
+        } else {
+          let trigger: (() => void) | undefined;
+          const promiseContext: PromiseContext = {
+            promiseCount: 1,
+            promise: new Promise((resolve) => {
+              trigger = resolve;
+            }),
+          } as PromiseContext;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          promiseContext.trigger = trigger!;
+          this._promiseContext = promiseContext;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        result.then((resolved) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const promiseContext = this._promiseContext!;
+          promiseContext.promiseCount--;
+          this._handlePossibleMultiPartResult(resolved);
+          if (promiseContext.promiseCount === 0) {
+            promiseContext.trigger();
+          }
+        });
+      } else {
+        this._handlePossibleMultiPartResult(result);
+      }
+    }
+
+    return this._promiseContext !== undefined
+      ? this._promiseContext.promise.then(() => this._return())
+      : this._return();
+  }
+
+  subscribe(): PromiseOrValue<
+    ExecutionResult | SimpleAsyncGenerator<ExecutionResult>
+  > {
+    const iteration = this.plan.map.entries().next();
+    if (iteration.done) {
+      const error = new GraphQLError('Could not route subscription.', {
+        nodes: this.operation,
+      });
+
+      return { errors: [error] };
+    }
+
+    const [subschema, subschemaSelections] = iteration.value;
+
+    const subscriber = subschema.subscriber;
+    if (!subscriber) {
+      const error = new GraphQLError(
+        'Subschema is not configured to execute subscription operation.',
+        { nodes: this.operation },
+      );
+
+      return { errors: [error] };
+    }
+
+    const document: DocumentNode = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        {
+          ...this.operation,
+          selectionSet: {
+            kind: Kind.SELECTION_SET,
+            selections: subschemaSelections,
+          },
+        },
+        ...this.fragments,
+      ],
+    };
+
+    const result = subscriber({
+      document,
+      variables: this.rawVariableValues,
+    });
+
+    if (isPromise(result)) {
+      return result.then((resolved) => this._handlePossibleStream(resolved));
+    }
+    return this._handlePossibleStream(result);
+  }
+
+  _return(): PromiseOrValue<
+    ExecutionResult | ExperimentalIncrementalExecutionResults
+  > {
+    const dataOrNull = this._nullData ? null : this._data;
+
+    if (this._consolidator !== undefined) {
+      this._consolidator.close();
+
+      const initialResult =
+        this._errors.length > 0
+          ? { data: dataOrNull, errors: this._errors, hasNext: true }
+          : { data: dataOrNull, hasNext: true };
+
+      return {
+        initialResult,
+        subsequentResults: this._consolidator,
+      };
+    }
+
+    return this._errors.length > 0
+      ? { data: dataOrNull, errors: this._errors }
+      : { data: dataOrNull };
+  }
+
+  _handlePossibleMultiPartResult<
+    T extends ExecutionResult | ExperimentalIncrementalExecutionResults,
+  >(result: T): void {
+    if ('initialResult' in result) {
+      this._handleSingleResult(result.initialResult);
+
+      if (this._consolidator === undefined) {
+        this._consolidator = new Consolidator<SubsequentIncrementalExecutionResult>([
+          result.subsequentResults,
+        ]);
+      } else {
+        this._consolidator.add(result.subsequentResults);
+      }
+    } else {
+      this._handleSingleResult(result);
+    }
+  }
+
+  _handleSingleResult(
+    result: ExecutionResult | InitialIncrementalExecutionResult,
+  ): void {
+    if (result.errors != null) {
+      this._errors.push(...result.errors);
+    }
+    if (this._nullData) {
+      return;
+    }
+    if (result.data == null) {
+      this._nullData = true;
+      return;
+    }
+
+    Object.assign(this._data, result.data);
+  }
+
+  _handlePossibleStream<
+    T extends ExecutionResult | SimpleAsyncGenerator<ExecutionResult>,
+  >(result: T): PromiseOrValue<T> {
+    if (isAsyncIterable(result)) {
+      return mapAsyncIterable(result, (payload) => payload) as T;
+    }
+
+    return result;
+  }
+}

--- a/src/stitch/PlanResult.ts
+++ b/src/stitch/PlanResult.ts
@@ -204,9 +204,10 @@ export class PlanResult {
       this._handleSingleResult(result.initialResult);
 
       if (this._consolidator === undefined) {
-        this._consolidator = new Consolidator<SubsequentIncrementalExecutionResult>([
-          result.subsequentResults,
-        ]);
+        this._consolidator =
+          new Consolidator<SubsequentIncrementalExecutionResult>([
+            result.subsequentResults,
+          ]);
       } else {
         this._consolidator.add(result.subsequentResults);
       }

--- a/src/utilities/Consolidator.ts
+++ b/src/utilities/Consolidator.ts
@@ -1,0 +1,134 @@
+import type { Push, Stop } from '@repeaterjs/repeater';
+import { Repeater } from '@repeaterjs/repeater';
+
+/**
+ * @internal
+ */
+export class Consolidator<T> extends Repeater<T> {
+  _asyncIterators: Set<AsyncIterator<T>>;
+  _push: Push<T> | undefined;
+  _stop: Stop | undefined;
+  _started: boolean;
+  _stopped: boolean;
+  _closed: boolean;
+  _finalIteration: IteratorReturnResult<unknown> | undefined;
+  _trigger!: () => void;
+  _signal: Promise<void>;
+  _advances: Map<
+    AsyncIterator<T>,
+    (value?: IteratorResult<unknown>) => unknown
+  >;
+
+  constructor(asyncIterables?: Array<AsyncIterable<T>>) {
+    super(async (push, stop) => {
+      this._push = push;
+      this._stop = stop;
+      this._started = true;
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      stop.then(() => {
+        this._stopped = true;
+        for (const advance of this._advances.values()) {
+          advance();
+        }
+      });
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        while (this._asyncIterators.size > 0) {
+          const promises: Array<Promise<void>> = [];
+          for (const asyncIterator of this._asyncIterators) {
+            promises.push(this._addAsyncIterator(asyncIterator));
+          }
+
+          // eslint-disable-next-line no-await-in-loop
+          await Promise.all(promises);
+        }
+
+        if (this._closed) {
+          stop();
+          return this._finalIteration?.value;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await this._signal;
+        this._signal = this._resetSignal();
+      }
+    });
+
+    this._asyncIterators = new Set();
+    if (asyncIterables) {
+      for (const asyncIterable of asyncIterables) {
+        this._asyncIterators.add(asyncIterable[Symbol.asyncIterator]());
+      }
+    }
+    this._started = false;
+    this._stopped = false;
+    this._closed = false;
+    this._advances = new Map();
+    this._signal = this._resetSignal();
+  }
+
+  _resetSignal(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this._trigger = resolve;
+    });
+  }
+
+  close(): void {
+    this._closed = true;
+    if (this._started) {
+      this._trigger();
+    }
+  }
+
+  add(value: AsyncIterable<T>): void {
+    if (this._closed) {
+      return;
+    }
+
+    this._asyncIterators.add(value[Symbol.asyncIterator]());
+
+    if (this._started) {
+      this._trigger();
+    }
+  }
+
+  async _addAsyncIterator(asyncIterator: AsyncIterator<T>): Promise<void> {
+    try {
+      while (!this._stopped) {
+        asyncIterator.next().then(
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          (iteration) => this._advances.get(asyncIterator)!(iteration),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          (err) => this._stop!(err),
+        );
+        const iteration: IteratorResult<unknown> | undefined =
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) =>
+            this._advances.set(asyncIterator, resolve),
+          );
+
+        if (iteration !== undefined) {
+          if (iteration.done) {
+            this._finalIteration = iteration;
+            return;
+          }
+
+          // eslint-disable-next-line no-await-in-loop, @typescript-eslint/no-non-null-assertion
+          await this._push!(iteration.value as T);
+        }
+      }
+    } finally {
+      this._advances.delete(asyncIterator);
+      this._asyncIterators.delete(asyncIterator);
+
+      if (this._closed && this._asyncIterators.size === 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this._stop!();
+      }
+
+      await asyncIterator.return?.();
+    }
+  }
+}

--- a/src/utilities/__tests__/Consolidator-test.ts
+++ b/src/utilities/__tests__/Consolidator-test.ts
@@ -1,0 +1,304 @@
+// adapted from https://github.com/repeaterjs/repeater/blob/219a0c8faf2c2768d234ecfe8dd21d455a4a98fe/packages/repeater/src/__tests__/combinators.ts
+
+import { Repeater } from '@repeaterjs/repeater';
+import { expect } from 'chai';
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import type { SinonFakeTimers } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
+
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
+
+import { Consolidator } from '../Consolidator.js';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+async function* gen<T>(
+  values: Array<T>,
+  returned: T,
+): AsyncIterableIterator<T> {
+  for (const value of values) {
+    yield value;
+  }
+  return returned;
+}
+
+async function* deferredGen<T>(
+  values: Array<T>,
+  returned: T,
+): AsyncIterableIterator<T> {
+  for (const value of values) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+    yield value;
+  }
+  return returned;
+}
+
+export async function* hangingGen<T = never>(): AsyncGenerator<T> {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  await new Promise(() => {});
+  /* c8 ignore next 2 */
+  yield Infinity as unknown as T;
+}
+
+function delayRepeater<T>(
+  wait: number,
+  values: Array<T>,
+  returned?: T,
+  error?: Error,
+): Repeater<T> {
+  return new Repeater<T>(async (push, stop) => {
+    let i = 0;
+    const timer = setInterval(() => {
+      if (i >= values.length) {
+        stop(error);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      push(values[i++]);
+    }, wait);
+    await stop;
+    clearInterval(timer);
+    return returned;
+  });
+}
+
+async function expectValues<T, R>(
+  asyncIterator: AsyncIterator<T>,
+  expectedValues: Array<T>,
+  expectedReturnValue: R,
+): Promise<void> {
+  const values: Array<T> = [];
+  let result: IteratorResult<T>;
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    result = await asyncIterator.next();
+    if (result.done) {
+      expect(result.value).to.deep.equal(expectedReturnValue);
+    } else {
+      values.push(result.value);
+    }
+  } while (!result.done);
+  expect(values).to.deep.equal(expectedValues);
+}
+
+describe('Consolidator', () => {
+  let clock: SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('empty', async () => {
+    const consolidator = new Consolidator();
+    consolidator.close();
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('empty calling stop after next', async () => {
+    const consolidator = new Consolidator();
+    const iteration = consolidator.next();
+    consolidator.close();
+    expect(await iteration).to.deep.equal({ done: true, value: undefined });
+  });
+
+  it('empty calling add after stop', async () => {
+    const consolidator = new Consolidator();
+    const iteration = consolidator.next();
+    consolidator.close();
+    consolidator.add(delayRepeater(100, [1, 2, 3], 4));
+    expect(await iteration).to.deep.equal({ done: true, value: undefined });
+  });
+
+  it('single iterator', async () => {
+    const consolidator = new Consolidator([delayRepeater(100, [1, 2, 3], 4)]);
+    consolidator.close();
+
+    const values = expectValues(consolidator, [1, 2, 3], 4);
+    clock.tick(1000);
+    await values;
+
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('single iterator calling add after next', async () => {
+    const consolidator = new Consolidator<number>();
+
+    const iteration = consolidator.next();
+
+    consolidator.add(delayRepeater(100, [1, 2, 3], 4));
+    consolidator.close();
+
+    const values = expectValues(consolidator, [2, 3], 4);
+    await clock.tickAsync(1000);
+    await values;
+
+    expect(await iteration).to.deep.equal({ done: false, value: 1 });
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('generator vs deferred generator', async () => {
+    const consolidator = new Consolidator([
+      gen([1, 2, 3, 4, 5], 6),
+      deferredGen([10, 20, 30, 40, 50], 60),
+    ]);
+    consolidator.close();
+
+    await expectValues(consolidator, [1, 10, 2, 20, 3, 30, 4, 40, 5, 50], 60);
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('generator vs later deferred generator', async () => {
+    const consolidator = new Consolidator([gen([1, 2, 3, 4, 5], 6)]);
+
+    consolidator.add(deferredGen([10, 20, 30, 40, 50], 60));
+    consolidator.close();
+
+    await expectValues(consolidator, [1, 10, 2, 20, 3, 30, 4, 40, 5, 50], 60);
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('deferred generator vs generator', async () => {
+    const consolidator = new Consolidator([
+      deferredGen([10, 20, 30, 40, 50], 60),
+      gen([1, 2, 3, 4, 5], 6),
+    ]);
+    consolidator.close();
+
+    await expectValues(consolidator, [1, 10, 2, 20, 3, 30, 4, 40, 5, 50], 60);
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('deferred generator vs later generator', async () => {
+    const consolidator = new Consolidator([deferredGen([10, 20, 30, 40, 50], 60)]);
+
+    consolidator.add(gen([1, 2, 3, 4, 5], 6));
+    consolidator.close();
+
+    await expectValues(consolidator, [1, 10, 2, 20, 3, 30, 4, 40, 5, 50], 60);
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('slow repeater vs fast repeater', async () => {
+    const consolidator = new Consolidator([
+      delayRepeater(160, [0, 1, 2, 3, 4], -2),
+      delayRepeater(100, [100, 101, 102, 103, 104, 105], -3),
+    ]);
+    consolidator.close();
+
+    const values = expectValues(
+      consolidator,
+      [100, 0, 101, 102, 1, 103, 2, 104, 105, 3, 4],
+      -2,
+    );
+    await clock.tickAsync(1000);
+    await values;
+
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('return methods called on all iterators when parent return called', async () => {
+    const iter1 = delayRepeater(100, [1]);
+    const iter2 = delayRepeater(10000, [2]);
+    const iter3 = new Repeater<number>(() => {
+      /* no-op */
+    });
+    const spy1 = spy(iter1, 'return');
+    const spy2 = spy(iter2, 'return');
+    const spy3 = spy(iter3, 'return');
+
+    const consolidator = new Consolidator([iter1, iter2, iter3]);
+    consolidator.close();
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    consolidator.next();
+    expect(await consolidator.return()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+    expect(spy1.calledOnce).to.equal(true);
+    expect(spy2.calledOnce).to.equal(true);
+    expect(spy3.calledOnce).to.equal(true);
+  });
+
+  it('return methods on all iterators not called when parent iterator return called prematurely', async () => {
+    const iter1 = hangingGen();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const iter2 = new Repeater<number>(() => {});
+    const iter3 = delayRepeater(10000, [1]);
+    const spy1 = spy(iter1, 'return');
+    const spy2 = spy(iter2, 'return');
+    const spy3 = spy(iter3, 'return');
+
+    const consolidator = new Consolidator([iter1, iter2, iter3]);
+    consolidator.close();
+
+    expect(await consolidator.return()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+    expect(spy1.notCalled).to.equal(true);
+    expect(spy2.notCalled).to.equal(true);
+    expect(spy3.notCalled).to.equal(true);
+  });
+
+  it('one iterator errors', async () => {
+    const iter1 = delayRepeater(100, Array(10).fill(101), 102);
+    const iter2 = new Repeater((push) => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      push(11);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      push(12);
+    });
+    const error = new Error('merge error');
+    const iter3 = delayRepeater(250, [1, 2, 3], undefined, error);
+    const spy1 = spy(iter1, 'return');
+    const spy2 = spy(iter2, 'return');
+    const spy3 = spy(iter3, 'return');
+
+    const consolidator = new Consolidator([iter1, iter2, iter3]);
+    consolidator.close();
+
+    const values = expectValues(
+      consolidator,
+      [11, 12, 101, 101, 1, 101, 101, 2, 101, 101, 101, 3, 101, 101],
+      NaN,
+    );
+    clock.tick(1000);
+    await expectPromise(values).toRejectWith('merge error');
+
+    expect(await consolidator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+    expect(spy1.calledOnce).to.equal(true);
+    expect(spy2.calledOnce).to.equal(true);
+    expect(spy3.calledOnce).to.equal(true);
+  });
+});

--- a/src/utilities/__tests__/Consolidator-test.ts
+++ b/src/utilities/__tests__/Consolidator-test.ts
@@ -190,7 +190,9 @@ describe('Consolidator', () => {
   });
 
   it('deferred generator vs later generator', async () => {
-    const consolidator = new Consolidator([deferredGen([10, 20, 30, 40, 50], 60)]);
+    const consolidator = new Consolidator([
+      deferredGen([10, 20, 30, 40, 50], 60),
+    ]);
 
     consolidator.add(gen([1, 2, 3, 4, 5], 6));
     consolidator.close();


### PR DESCRIPTION
Fields for an operation are split to different subschemas, and the results are merged.

Previously, we would wait to merge until the executors for all subschemas returned; now, we merge results as they return, including the asyncIterators. This requires an abstraction for merging asyncIterators dynamically, which is accomplished by the new Consolidator abstraction.

This same abstraction will allow us to merge in stitched asyncIterators as they return just by pushing the mapped asyncIterators to the consolidator.