### PR TITLE
add back initial defer stitching support

### DIFF
--- a/src/predicates/isDeferResult.ts
+++ b/src/predicates/isDeferResult.ts
@@ -1,0 +1,7 @@
+import type { IncrementalDeferResult, IncrementalResult } from 'graphql';
+
+export function isDeferIncrementalResult(
+  incrementalResult: IncrementalResult,
+): incrementalResult is IncrementalDeferResult {
+  return 'data' in incrementalResult;
+}

--- a/src/stitch/PlannedOperation.ts
+++ b/src/stitch/PlannedOperation.ts
@@ -3,18 +3,20 @@ import type {
   ExecutionResult,
   ExperimentalIncrementalExecutionResults,
   FragmentDefinitionNode,
+  IncrementalResult,
   InitialIncrementalExecutionResult,
   OperationDefinitionNode,
   SelectionNode,
   SubsequentIncrementalExecutionResult,
 } from 'graphql';
 import { GraphQLError, Kind } from 'graphql';
-import type { ObjMap } from 'graphql/jsutils/ObjMap.js';
 
+import type { ObjMap } from '../types/ObjMap.js';
 import type { PromiseOrValue } from '../types/PromiseOrValue.js';
 import type { SimpleAsyncGenerator } from '../types/SimpleAsyncGenerator.js';
 
 import { isAsyncIterable } from '../predicates/isAsyncIterable.js';
+import { isDeferIncrementalResult } from '../predicates/isDeferResult.js';
 import { isObjectLike } from '../predicates/isObjectLike.js';
 import { isPromise } from '../predicates/isPromise.js';
 import { Consolidator } from '../utilities/Consolidator.js';
@@ -27,6 +29,13 @@ interface PromiseContext {
   promise: Promise<void>;
   trigger: () => void;
 }
+
+interface TaggedSubsequentIncrementalExecutionResult {
+  path: Path;
+  incrementalResult: SubsequentIncrementalExecutionResult;
+}
+
+type Path = ReadonlyArray<string | number>;
 
 /**
  * @internal
@@ -44,8 +53,14 @@ export class PlannedOperation {
   _data: ObjMap<unknown>;
   _nullData: boolean;
   _errors: Array<GraphQLError>;
-  _consolidator: Consolidator<SubsequentIncrementalExecutionResult> | undefined;
+  _consolidator:
+    | Consolidator<
+        TaggedSubsequentIncrementalExecutionResult,
+        SubsequentIncrementalExecutionResult
+      >
+    | undefined;
 
+  _deferredResults: Map<string, Array<ObjMap<unknown>>>;
   _promiseContext: PromiseContext | undefined;
 
   constructor(
@@ -65,6 +80,7 @@ export class PlannedOperation {
     this._data = Object.create(null);
     this._nullData = false;
     this._errors = [];
+    this._deferredResults = new Map();
   }
 
   execute(): PromiseOrValue<
@@ -76,7 +92,7 @@ export class PlannedOperation {
         variables: this.rawVariableValues,
       });
 
-      this._handleMaybeAsyncPossibleMultiPartResult(this._data, result);
+      this._handleMaybeAsyncPossibleMultiPartResult(this._data, result, []);
     }
 
     return this._promiseContext !== undefined
@@ -185,7 +201,7 @@ export class PlannedOperation {
     T extends PromiseOrValue<
       ExecutionResult | ExperimentalIncrementalExecutionResults
     >,
-  >(parent: ObjMap<unknown>, result: T): void {
+  >(parent: ObjMap<unknown>, result: T, path: Path): void {
     if (isPromise(result)) {
       const promiseContext = this._incrementPromiseContext();
       result.then(
@@ -194,23 +210,34 @@ export class PlannedOperation {
             parent,
             promiseContext,
             resolved,
+            path,
           ),
         (err) =>
-          this._handleAsyncPossibleMultiPartResult(parent, promiseContext, {
-            data: null,
-            errors: [new GraphQLError(err.message, { originalError: err })],
-          }),
+          this._handleAsyncPossibleMultiPartResult(
+            parent,
+            promiseContext,
+            {
+              data: null,
+              errors: [new GraphQLError(err.message, { originalError: err })],
+            },
+            path,
+          ),
       );
     } else {
-      this._handlePossibleMultiPartResult(parent, result);
+      this._handlePossibleMultiPartResult(parent, result, path);
     }
   }
 
   _handleAsyncPossibleMultiPartResult<
     T extends ExecutionResult | ExperimentalIncrementalExecutionResults,
-  >(parent: ObjMap<unknown>, promiseContext: PromiseContext, result: T): void {
+  >(
+    parent: ObjMap<unknown>,
+    promiseContext: PromiseContext,
+    result: T,
+    path: Path,
+  ): void {
     promiseContext.promiseCount--;
-    this._handlePossibleMultiPartResult(parent, result);
+    this._handlePossibleMultiPartResult(parent, result, path);
     if (promiseContext.promiseCount === 0) {
       promiseContext.trigger();
     }
@@ -218,26 +245,122 @@ export class PlannedOperation {
 
   _handlePossibleMultiPartResult<
     T extends ExecutionResult | ExperimentalIncrementalExecutionResults,
-  >(parent: ObjMap<unknown>, result: T): void {
-    if ('initialResult' in result) {
-      this._handleSingleResult(parent, result.initialResult);
-
-      if (this._consolidator === undefined) {
-        this._consolidator =
-          new Consolidator<SubsequentIncrementalExecutionResult>([
-            result.subsequentResults,
-          ]);
-      } else {
-        this._consolidator.add(result.subsequentResults);
-      }
-    } else {
-      this._handleSingleResult(parent, result);
+  >(parent: ObjMap<unknown>, result: T, path: Path): void {
+    if (!('initialResult' in result)) {
+      this._handleSingleResult(parent, result, path);
+      return;
     }
+
+    const { initialResult, subsequentResults } = result;
+
+    this._handleSingleResult(parent, initialResult, path);
+
+    const taggedResults = mapAsyncIterable(
+      subsequentResults,
+      (incrementalResult) => ({
+        path,
+        incrementalResult,
+      }),
+    );
+
+    if (this._consolidator === undefined) {
+      this._consolidator = new Consolidator([taggedResults], (taggedResult) =>
+        this._handleIncrementalResult(taggedResult),
+      );
+      return;
+    }
+
+    this._consolidator.add(taggedResults);
+  }
+
+  _handleIncrementalResult(
+    taggedResult: TaggedSubsequentIncrementalExecutionResult,
+  ): SubsequentIncrementalExecutionResult | undefined {
+    const { path, incrementalResult } = taggedResult;
+    if (incrementalResult.incremental === undefined) {
+      return incrementalResult;
+    }
+
+    const newIncremental: Array<IncrementalResult> = [];
+
+    for (const result of incrementalResult.incremental) {
+      if (!isDeferIncrementalResult(result)) {
+        newIncremental.push(result);
+        continue;
+      }
+
+      const data = result.data;
+
+      if (data == null) {
+        newIncremental.push(result);
+        continue;
+      }
+
+      let identifier: string | undefined;
+      const newData = Object.create(null);
+      for (const key of Object.keys(data)) {
+        if (!key.startsWith('__identifier')) {
+          newData[key] = data[key];
+          continue;
+        }
+        identifier = key;
+      }
+
+      if (identifier === undefined) {
+        newIncremental.push(result);
+        continue;
+      }
+
+      const fullPath = result.path ? [...path, ...result.path] : path;
+      const key = fullPath.join();
+
+      const total = parseInt(identifier.split('__')[3], 10);
+      const deferredResults = this._deferredResults.get(key);
+      if (deferredResults === undefined) {
+        this._deferredResults.set(key, [newData]);
+        continue;
+      }
+
+      if (deferredResults.length !== total - 1) {
+        deferredResults.push(newData);
+        continue;
+      }
+
+      for (const deferredResult of deferredResults) {
+        for (const [deferredKey, value] of Object.entries(deferredResult)) {
+          newData[deferredKey] = value;
+        }
+      }
+
+      this._deferredResults.delete(key);
+
+      newIncremental.push({
+        ...result,
+        data: newData,
+        path: fullPath,
+      });
+    }
+
+    if (newIncremental.length === 0) {
+      return undefined;
+    }
+
+    const newIncrementalResult = {
+      ...incrementalResult,
+      incremental: newIncremental,
+    };
+
+    if (this._deferredResults.size) {
+      newIncrementalResult.hasNext = true;
+    }
+
+    return newIncrementalResult;
   }
 
   _handleSingleResult(
     parent: ObjMap<unknown>,
     result: ExecutionResult | InitialIncrementalExecutionResult,
+    path: Path,
   ): void {
     if (result.errors != null) {
       this._errors.push(...result.errors);
@@ -254,15 +377,20 @@ export class PlannedOperation {
       this._deepMerge(parent, key, value);
     }
 
-    this._executeSubPlans(result.data, this.plan.subPlans);
+    this._executeSubPlans(result.data, this.plan.subPlans, path);
   }
 
-  _executeSubPlans(data: ObjMap<unknown>, subPlans: ObjMap<Plan>): void {
+  _executeSubPlans(
+    data: ObjMap<unknown>,
+    subPlans: ObjMap<Plan>,
+    path: Path,
+  ): void {
     for (const [key, subPlan] of Object.entries(subPlans)) {
       if (data[key]) {
         this._executePossibleListSubPlan(
           data[key] as ObjMap<unknown> | Array<unknown>,
           subPlan,
+          [...path, key],
         );
       }
     }
@@ -271,28 +399,29 @@ export class PlannedOperation {
   _executePossibleListSubPlan(
     parent: ObjMap<unknown> | Array<unknown>,
     plan: Plan,
+    path: Path,
   ): void {
     if (Array.isArray(parent)) {
-      for (const item of parent) {
-        this._executePossibleListSubPlan(item, plan);
+      for (let i = 0; i < parent.length; i++) {
+        this._executePossibleListSubPlan(parent[i], plan, [...path, i]);
       }
       return;
     }
 
-    this._executeSubPlan(parent, plan);
+    this._executeSubPlan(parent, plan, path);
   }
 
-  _executeSubPlan(parent: ObjMap<unknown>, plan: Plan): void {
+  _executeSubPlan(parent: ObjMap<unknown>, plan: Plan, path: Path): void {
     for (const [subschema, subschemaSelections] of plan.map.entries()) {
       const result = subschema.executor({
         document: this._createDocument(subschemaSelections),
         variables: this.rawVariableValues,
       });
 
-      this._handleMaybeAsyncPossibleMultiPartResult(parent, result);
+      this._handleMaybeAsyncPossibleMultiPartResult(parent, result, path);
     }
 
-    this._executeSubPlans(parent, plan.subPlans);
+    this._executeSubPlans(parent, plan.subPlans, path);
   }
 
   _deepMerge(parent: ObjMap<unknown>, key: string, value: unknown): void {

--- a/src/stitch/SuperSchema.ts
+++ b/src/stitch/SuperSchema.ts
@@ -29,7 +29,7 @@ import type {
 } from 'graphql';
 import {
   coerceInputValue,
-  execute,
+  experimentalExecuteIncrementally,
   GraphQLDirective,
   GraphQLEnumType,
   GraphQLError,
@@ -139,7 +139,7 @@ export class SuperSchema {
     const introspectionSubschema: Subschema = {
       schema: this.mergedSchema,
       executor: (args) =>
-        execute({
+        experimentalExecuteIncrementally({
           ...args,
           schema: this.mergedSchema,
         }),

--- a/src/stitch/__tests__/PlannedOperation-test.ts
+++ b/src/stitch/__tests__/PlannedOperation-test.ts
@@ -1,8 +1,22 @@
 import { expect } from 'chai';
-import type { GraphQLSchema, OperationDefinitionNode } from 'graphql';
-import { buildSchema, execute, OperationTypeNode, parse } from 'graphql';
+import type {
+  ExecutionResult,
+  ExperimentalIncrementalExecutionResults,
+  GraphQLSchema,
+  InitialIncrementalExecutionResult,
+  OperationDefinitionNode,
+  SubsequentIncrementalExecutionResult,
+} from 'graphql';
+import {
+  buildSchema,
+  experimentalExecuteIncrementally,
+  OperationTypeNode,
+  parse,
+} from 'graphql';
+import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import { describe, it } from 'mocha';
 
+import { isPromise } from '../../predicates/isPromise.js';
 import { invariant } from '../../utilities/invariant.js';
 
 import { Plan } from '../Plan.js';
@@ -14,7 +28,7 @@ function getSubschema(schema: GraphQLSchema, rootValue: unknown): Subschema {
   return {
     schema,
     executor: (args) =>
-      execute({
+      experimentalExecuteIncrementally({
         ...args,
         schema,
         rootValue,
@@ -38,6 +52,31 @@ function createPlannedOperation(
   );
 
   return new PlannedOperation(plan, operation, [], undefined);
+}
+
+async function complete(
+  maybePromisedResult: PromiseOrValue<
+    ExecutionResult | ExperimentalIncrementalExecutionResults
+  >,
+): Promise<
+  | ExecutionResult
+  | Array<
+      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    >
+> {
+  const result = isPromise(maybePromisedResult)
+    ? await maybePromisedResult
+    : maybePromisedResult;
+  if ('initialResult' in result) {
+    const results: Array<
+      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    > = [result.initialResult];
+    for await (const subsequentResult of result.subsequentResults) {
+      results.push(subsequentResult);
+    }
+    return results;
+  }
+  return result;
 }
 
 describe('PlannedOperation', () => {
@@ -403,6 +442,84 @@ describe('PlannedOperation', () => {
           ],
         },
       });
+    });
+  });
+
+  describe('stitching with defer', () => {
+    it('works to stitch subfields', async () => {
+      const someSchema = buildSchema(`
+        type Query {
+          someObject: [SomeObject]
+        }
+
+        type SomeObject {
+          someField: [String]
+        }
+    `);
+
+      const anotherSchema = buildSchema(`
+        type Query {
+          someObject: [SomeObject]
+          anotherField: [String]
+        }
+
+        type SomeObject {
+          anotherField: [String]
+        }
+      `);
+
+      const someSubschema = getSubschema(someSchema, {
+        someObject: [
+          { someField: ['someFieldA'] },
+          { someField: ['someFieldB'] },
+        ],
+      });
+      const anotherSubschema = getSubschema(anotherSchema, {
+        anotherField: ['anotherField'],
+      });
+      const superSchema = new SuperSchema([someSubschema, anotherSubschema]);
+
+      const operation = parse(
+        '{ someObject { ... @defer { someField anotherField } } }',
+        {
+          noLocation: true,
+        },
+      ).definitions[0] as OperationDefinitionNode;
+
+      const plannedOperation = createPlannedOperation(superSchema, operation);
+
+      expect(await complete(plannedOperation.execute())).to.deep.equal([
+        {
+          data: { someObject: [{}, {}] },
+          hasNext: true,
+        },
+        {
+          incremental: [
+            {
+              data: {
+                someField: ['someFieldA'],
+                anotherField: ['anotherField'],
+              },
+
+              path: ['someObject', 0],
+            },
+          ],
+          hasNext: true,
+        },
+        {
+          incremental: [
+            {
+              data: {
+                someField: ['someFieldB'],
+                anotherField: ['anotherField'],
+              },
+
+              path: ['someObject', 1],
+            },
+          ],
+          hasNext: false,
+        },
+      ]);
     });
   });
 });

--- a/src/utilities/UniqueId.ts
+++ b/src/utilities/UniqueId.ts
@@ -1,0 +1,14 @@
+/**
+ * @internal
+ */
+export class UniqueId {
+  _id: number;
+
+  constructor() {
+    this._id = 0;
+  }
+
+  gen(): string {
+    return (this._id++).toString();
+  }
+}

--- a/src/utilities/__tests__/Consolidator-test.ts
+++ b/src/utilities/__tests__/Consolidator-test.ts
@@ -130,7 +130,7 @@ describe('Consolidator', () => {
   });
 
   it('single iterator calling add after next', async () => {
-    const consolidator = new Consolidator<number>();
+    const consolidator = new Consolidator<number, number>();
 
     const iteration = consolidator.next();
 


### PR DESCRIPTION
The consolidator has to properly stitch together deferred secondary payloads into deferred primary payloads. This is done by:

1. adding a dummy field with alias to label any fragment with deferred payloads with the total number of payloads expected.
2. augmenting deferred stream results with the path that kicked them off, so the secondary path can be concatenated. This will have to be customized as we get into more  complex scenarios.
3. changing the consolidator to allow skipping a deferred payload if all of its secondaries are not complete
4. adding a map to save incomplete deferred payloads for later merging