### PR TITLE
small refactors

### DIFF
--- a/src/stitch/Plan.ts
+++ b/src/stitch/Plan.ts
@@ -293,7 +293,7 @@ export class Plan {
     identifier: string,
     includeIf: ValueNode | undefined,
   ): Array<SelectionNode> {
-    const field: FieldNode = {
+    const identifierField: FieldNode = {
       kind: Kind.FIELD,
       name: {
         kind: Kind.NAME,
@@ -326,7 +326,7 @@ export class Plan {
         : undefined,
     };
 
-    return [...selections, field];
+    return [identifierField, ...selections];
   }
 
   print(indent = 0): string {

--- a/src/stitch/__tests__/Plan-test.ts
+++ b/src/stitch/__tests__/Plan-test.ts
@@ -217,15 +217,15 @@ describe('Plan', () => {
     `);
   });
 
-  it('works with defer', () => {
+  it('works with @defer directive on merged types', () => {
     const someSchema = buildSchema(`
-        type Query {
-          someObject: [SomeObject]
-        }
+      type Query {
+        someObject: [SomeObject]
+      }
 
-        type SomeObject {
-          someField: [String]
-        }
+      type SomeObject {
+        someField: [String]
+      }
     `);
 
     const anotherSchema = buildSchema(`

--- a/src/stitch/__tests__/Plan-test.ts
+++ b/src/stitch/__tests__/Plan-test.ts
@@ -271,6 +271,6 @@ describe('Plan', () => {
                 __identifier__0__2: __typename
               }
             }
-`);
+    `);
   });
 });

--- a/src/stitch/__tests__/Plan-test.ts
+++ b/src/stitch/__tests__/Plan-test.ts
@@ -257,8 +257,8 @@ describe('Plan', () => {
           {
             someObject {
               ... @defer {
-                someField
                 __identifier__0__2: __typename
+                someField
               }
             }
           }
@@ -267,8 +267,8 @@ describe('Plan', () => {
           Subschema 1:
             {
               ... @defer {
-                anotherField
                 __identifier__0__2: __typename
+                anotherField
               }
             }
     `);


### PR DESCRIPTION
1. indents
2. test names
3. order of identifier fields (just to prettify, we can't change algorithm, because by spec preservation of operation field order is a norm, but not required (SHOULD but not MUST)
4. additional test case