### PR TITLE
eval skip/include prior to planning

### DIFF
--- a/src/stitch/__tests__/Executor-test.ts
+++ b/src/stitch/__tests__/Executor-test.ts
@@ -7,7 +7,7 @@ import { invariant } from '../../utilities/invariant.js';
 
 import { Executor } from '../Executor.js';
 import { Plan } from '../Plan.js';
-import type { Subschema } from '../SuperSchema.js';
+import type { OperationContext, Subschema } from '../SuperSchema.js';
 import { SuperSchema } from '../SuperSchema.js';
 
 function getSubschema(schema: GraphQLSchema, rootValue: unknown): Subschema {
@@ -31,10 +31,9 @@ function createExecutor(
   invariant(queryType !== undefined);
 
   const plan = new Plan(
-    superSchema,
+    { superSchema, fragmentMap: {} } as OperationContext,
     queryType,
     operation.selectionSet.selections,
-    {},
   );
 
   return new Executor(plan, operation, [], undefined);

--- a/src/stitch/__tests__/Plan-test.ts
+++ b/src/stitch/__tests__/Plan-test.ts
@@ -8,7 +8,7 @@ import { dedent } from '../../__testUtils__/dedent.js';
 import { invariant } from '../../utilities/invariant.js';
 
 import { Plan } from '../Plan.js';
-import type { Subschema } from '../SuperSchema.js';
+import type { OperationContext, Subschema } from '../SuperSchema.js';
 import { SuperSchema } from '../SuperSchema.js';
 
 function getSubschema(schema: GraphQLSchema): Subschema {
@@ -31,10 +31,9 @@ function createPlan(
   invariant(queryType !== undefined);
 
   return new Plan(
-    superSchema,
+    { superSchema, fragmentMap: {} } as OperationContext,
     queryType,
     operation.selectionSet.selections,
-    {},
   );
 }
 

--- a/src/stitch/execute.ts
+++ b/src/stitch/execute.ts
@@ -6,7 +6,7 @@ import type { PromiseOrValue } from '../types/PromiseOrValue.js';
 import type { ExecutionArgs } from './buildExecutionContext.js';
 import { buildExecutionContext } from './buildExecutionContext.js';
 import { Executor } from './Executor.js';
-import { Plan } from './Plan.js';
+import { createPlan } from './Plan.js';
 
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   // If a valid execution context cannot be created due to incorrect arguments,
@@ -18,10 +18,8 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { errors: exeContext };
   }
 
-  const {
-    operationContext: { superSchema, operation, fragments, fragmentMap },
-    rawVariableValues,
-  } = exeContext;
+  const { operationContext, rawVariableValues } = exeContext;
+  const { superSchema, operation, fragments } = operationContext;
 
   const rootType = superSchema.getRootType(operation.operation);
 
@@ -34,11 +32,10 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { data: null, errors: [error] };
   }
 
-  const plan = new Plan(
-    superSchema,
+  const plan = createPlan(
+    operationContext,
     rootType,
     operation.selectionSet.selections,
-    fragmentMap,
   );
 
   const executor = new Executor(plan, operation, fragments, rawVariableValues);

--- a/src/stitch/subscribe.ts
+++ b/src/stitch/subscribe.ts
@@ -9,7 +9,7 @@ import { invariant } from '../utilities/invariant.js';
 import type { ExecutionArgs } from './buildExecutionContext.js';
 import { buildExecutionContext } from './buildExecutionContext.js';
 import { Executor } from './Executor.js';
-import { Plan } from './Plan.js';
+import { createPlan } from './Plan.js';
 
 export function subscribe(
   args: ExecutionArgs,
@@ -23,10 +23,8 @@ export function subscribe(
     return { errors: exeContext };
   }
 
-  const {
-    operationContext: { superSchema, operation, fragments, fragmentMap },
-    rawVariableValues,
-  } = exeContext;
+  const { operationContext, rawVariableValues } = exeContext;
+  const { superSchema, operation, fragments } = operationContext;
   invariant(operation.operation === OperationTypeNode.SUBSCRIPTION);
 
   const rootType = superSchema.getRootType(operation.operation);
@@ -40,11 +38,10 @@ export function subscribe(
     return { errors: [error] };
   }
 
-  const plan = new Plan(
-    superSchema,
+  const plan = createPlan(
+    operationContext,
     rootType,
     operation.selectionSet.selections,
-    fragmentMap,
   );
 
   const executor = new Executor(plan, operation, fragments, rawVariableValues);

--- a/src/utilities/__tests__/applySkipIncludeDirectives-test.ts
+++ b/src/utilities/__tests__/applySkipIncludeDirectives-test.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import type { OperationDefinitionNode } from 'graphql';
+import { getOperationAST, parse, print } from 'graphql';
+import { describe, it } from 'mocha';
+
+import { dedent } from '../../__testUtils__/dedent.js';
+
+import { applySkipIncludeDirectives } from '../applySkipIncludeDirectives.js';
+
+describe('applySkipIncludeDirectives', () => {
+  it('can apply directives', () => {
+    const document = parse(dedent`
+      query withSkipInclude($skipA: Boolean, $skipB: Boolean, $includeC: Boolean, $includeD: Boolean) {
+        a @skip(if: $skipA) 
+        b @skip(if: $skipB)
+        c @include(if: $includeC)
+        d @include(if: $includeD)
+      }
+    `);
+
+    const operation = getOperationAST(
+      document,
+      'withSkipInclude',
+    ) as OperationDefinitionNode;
+    const transformedAST = applySkipIncludeDirectives(operation, {
+      skipA: true,
+      skipB: false,
+      includeC: true,
+      includeD: false,
+    });
+
+    expect(print(transformedAST)).to.equal(dedent`
+      query withSkipInclude($skipA: Boolean, $skipB: Boolean, $includeC: Boolean, $includeD: Boolean) {
+        b @skip(if: $skipB)
+        c @include(if: $includeC)
+      }
+    `);
+  });
+
+  it('maintains cache', () => {
+    const document = parse(dedent`
+      query withSkipInclude($skipA: Boolean, $skipB: Boolean, $includeC: Boolean, $includeD: Boolean) {
+        a @skip(if: $skipA) 
+        b @skip(if: $skipB)
+        c @include(if: $includeC)
+        d @include(if: $includeD)
+      }
+    `);
+
+    const operation = getOperationAST(
+      document,
+      'withSkipInclude',
+    ) as OperationDefinitionNode;
+    const aTransformedAST = applySkipIncludeDirectives(operation, {
+      skipA: true,
+      skipB: false,
+      includeC: true,
+      includeD: false,
+    });
+
+    const anotherTransformedAST = applySkipIncludeDirectives(operation, {
+      skipA: true,
+      skipB: false,
+      includeC: true,
+      includeD: false,
+    });
+
+    expect(aTransformedAST).to.equal(anotherTransformedAST);
+  });
+});

--- a/src/utilities/appendToArray.ts
+++ b/src/utilities/appendToArray.ts
@@ -1,0 +1,8 @@
+import { memoize2 } from './memoize2.js';
+
+export const emptyArray: Array<object> = [];
+
+function _appendToArray<T extends object>(arr: Array<T>, item: T) {
+  return [...arr, item];
+}
+export const appendToArray = memoize2(_appendToArray);

--- a/src/utilities/applySkipIncludeDirectives.ts
+++ b/src/utilities/applySkipIncludeDirectives.ts
@@ -1,0 +1,87 @@
+import type {
+  ASTNode,
+  DirectiveNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+} from 'graphql';
+import {
+  getArgumentValues,
+  GraphQLIncludeDirective,
+  GraphQLSkipDirective,
+  Kind,
+} from 'graphql';
+
+import { appendToArray, emptyArray } from './appendToArray.js';
+import { memoize2 } from './memoize2.js';
+import { updateNode } from './updateNode.js';
+import { visitWithMemo } from './visitWithMemo.js';
+
+/**
+ * Function that applies the @skip and @include directives to a given OperationDefinitionNode or FragmentDefinitionNode.
+ */
+export const applySkipIncludeDirectives = memoize2(_applySkipIncludeDirectives);
+
+function _applySkipIncludeDirectives<
+  T extends OperationDefinitionNode | FragmentDefinitionNode,
+>(node: T, variableValues: { [key: string]: unknown }): T {
+  return visitWithMemo(
+    node,
+    {
+      [Kind.FIELD]: (fieldNode) =>
+        applyDirectivesToSelection(fieldNode, variableValues),
+      [Kind.FRAGMENT_SPREAD]: (spreadNode) =>
+        applyDirectivesToSelection(spreadNode, variableValues),
+      [Kind.INLINE_FRAGMENT]: (spreadNode) =>
+        applyDirectivesToSelection(spreadNode, variableValues),
+    },
+    {
+      OperationDefinition: ['selectionSet'],
+      SelectionSet: ['selections'],
+      Field: ['selectionSet'],
+      InlineFragment: ['selectionSet'],
+      FragmentDefinition: ['selectionSet'],
+    },
+  );
+}
+
+function applyDirectivesToSelection(
+  node: FieldNode | FragmentSpreadNode | InlineFragmentNode,
+  variableValues: { [key: string]: unknown },
+): ASTNode | null {
+  const directives: ReadonlyArray<DirectiveNode> | undefined = node.directives;
+
+  if (directives === undefined) {
+    return node;
+  }
+
+  let newDirectives = emptyArray as Array<DirectiveNode>;
+
+  for (const directive of directives) {
+    const directiveName = directive.name.value;
+    if (directiveName === 'skip') {
+      const directiveValues = getArgumentValues(
+        GraphQLSkipDirective,
+        directive,
+        variableValues,
+      );
+      if (directiveValues.if === true) {
+        return null;
+      }
+    } else if (directiveName === 'include') {
+      const directiveValues = getArgumentValues(
+        GraphQLIncludeDirective,
+        directive,
+        variableValues,
+      );
+      if (directiveValues.if === false) {
+        return null;
+      }
+    }
+    newDirectives = appendToArray(newDirectives, directive);
+  }
+
+  return updateNode(node, 'directives', newDirectives);
+}

--- a/src/utilities/inlineRootFragments.ts
+++ b/src/utilities/inlineRootFragments.ts
@@ -3,7 +3,9 @@ import { Kind } from 'graphql';
 
 import type { ObjMap } from '../types/ObjMap';
 
-export function inlineRootFragments(
+import { memoize2 } from './memoize2.js';
+
+function _inlineRootFragments(
   selections: ReadonlyArray<SelectionNode>,
   fragmentMap: ObjMap<FragmentDefinitionNode>,
   visitedFragments = new Set<string>(),
@@ -19,7 +21,7 @@ export function inlineRootFragments(
           ...selection,
           selectionSet: {
             kind: Kind.SELECTION_SET,
-            selections: inlineRootFragments(
+            selections: _inlineRootFragments(
               selection.selectionSet.selections,
               fragmentMap,
               visitedFragments,
@@ -40,7 +42,7 @@ export function inlineRootFragments(
             typeCondition: fragment.typeCondition,
             selectionSet: {
               kind: Kind.SELECTION_SET,
-              selections: inlineRootFragments(
+              selections: _inlineRootFragments(
                 fragment.selectionSet.selections,
                 fragmentMap,
                 visitedFragments,
@@ -54,3 +56,5 @@ export function inlineRootFragments(
 
   return newSelections;
 }
+
+export const inlineRootFragments = memoize2(_inlineRootFragments);

--- a/src/utilities/memoize2.ts
+++ b/src/utilities/memoize2.ts
@@ -1,0 +1,27 @@
+/**
+ * Memoizes the provided two-argument function.
+ */
+export function memoize2<A1 extends object, A2 extends object, R>(
+  fn: (a1: A1, a2: A2) => R,
+): (a1: A1, a2: A2) => R {
+  const cache0 = new WeakMap<A1, WeakMap<A2, R>>();
+
+  return function memoized(a1, a2) {
+    let cache1 = cache0.get(a1);
+    if (cache1 === undefined) {
+      cache1 = new WeakMap();
+      cache0.set(a1, cache1);
+      const fnResult = fn(a1, a2);
+      cache1.set(a2, fnResult);
+      return fnResult;
+    }
+
+    let fnResult = cache1.get(a2);
+    if (fnResult === undefined) {
+      fnResult = fn(a1, a2);
+      cache1.set(a2, fnResult);
+    }
+
+    return fnResult;
+  };
+}

--- a/src/utilities/memoize3.ts
+++ b/src/utilities/memoize3.ts
@@ -1,0 +1,40 @@
+/**
+ * Memoizes the provided three-argument function.
+ */
+export function memoize3<
+  A1 extends object,
+  A2 extends object,
+  A3 extends object,
+  R,
+>(fn: (a1: A1, a2: A2, a3: A3) => R): (a1: A1, a2: A2, a3: A3) => R {
+  const cache0 = new WeakMap<A1, WeakMap<A2, WeakMap<A3, R>>>();
+
+  return function memoized(a1, a2, a3) {
+    let cache1 = cache0.get(a1);
+    if (cache1 === undefined) {
+      cache1 = new WeakMap();
+      cache0.set(a1, cache1);
+      const cache2 = new WeakMap();
+      cache1.set(a2, cache2);
+      const fnResult = fn(a1, a2, a3);
+      cache2.set(a3, fnResult);
+      return fnResult;
+    }
+
+    let cache2 = cache1.get(a2);
+    if (cache2 === undefined) {
+      cache2 = new WeakMap();
+      cache1.set(a2, cache2);
+      const fnResult = fn(a1, a2, a3);
+      cache2.set(a3, fnResult);
+    }
+
+    let fnResult = cache2.get(a3);
+    if (fnResult === undefined) {
+      fnResult = fn(a1, a2, a3);
+      cache2.set(a3, fnResult);
+    }
+
+    return fnResult;
+  };
+}

--- a/src/utilities/updateNode.ts
+++ b/src/utilities/updateNode.ts
@@ -1,0 +1,41 @@
+const objectCaches = new WeakMap<
+  object,
+  Map<string, Map<unknown, { [key: string]: unknown }>>
+>();
+
+export function updateNode<T extends object>(
+  node: T,
+  key: string,
+  value: any,
+): T {
+  let cacheForNode = objectCaches.get(node);
+  if (cacheForNode === undefined) {
+    cacheForNode = new Map();
+    objectCaches.set(node, cacheForNode);
+  }
+
+  let cacheForKey = cacheForNode.get(key);
+  if (cacheForKey === undefined) {
+    cacheForKey = new Map();
+    cacheForNode.set(key, cacheForKey);
+  }
+
+  let cachedValue = cacheForKey.get(value);
+  if (cachedValue === undefined) {
+    cachedValue = {};
+    for (const nodeKey of Object.keys(node)) {
+      if (nodeKey === key) {
+        if (value !== null) {
+          cachedValue[nodeKey] = value;
+        }
+        continue;
+      }
+      cachedValue[nodeKey] = (
+        node as unknown as { [nodeKey: string]: unknown }
+      )[nodeKey];
+    }
+    cacheForKey.set(value, cachedValue);
+  }
+
+  return cachedValue as T;
+}

--- a/src/utilities/visitWithMemo.ts
+++ b/src/utilities/visitWithMemo.ts
@@ -1,0 +1,438 @@
+// adapted from graphql-js
+
+import type { ASTNode } from 'graphql';
+import { Kind } from 'graphql';
+
+import { appendToArray, emptyArray } from './appendToArray.js';
+import { updateNode } from './updateNode.js';
+
+/**
+ * A visitor is provided to visit, it contains the collection of
+ * relevant functions to be called during the visitor's traversal.
+ */
+type ASTVisitor = EnterLeaveVisitor<ASTNode> | KindVisitor;
+
+type KindVisitor = {
+  readonly [NodeT in ASTNode as NodeT['kind']]?:
+    | ASTVisitFn<NodeT>
+    | EnterLeaveVisitor<NodeT>;
+};
+
+interface EnterLeaveVisitor<TVisitedNode extends ASTNode> {
+  readonly enter?: ASTVisitFn<TVisitedNode> | undefined;
+  readonly leave?: ASTVisitFn<TVisitedNode> | undefined;
+}
+
+/**
+ * A visitor is comprised of visit functions, which are called on each node
+ * during the visitor's traversal.
+ */
+type ASTVisitFn<TVisitedNode extends ASTNode> = (
+  /** The current node being visiting. */
+  node: TVisitedNode,
+  /** The index or key to this node from the parent node or Array. */
+  key: string | number | undefined,
+  /** The parent immediately above this node, which may be an Array. */
+  parent: ASTNode | ReadonlyArray<ASTNode> | undefined,
+  /** The key path to get to this node from the root node. */
+  path: ReadonlyArray<string | number>,
+  /**
+   * All nodes and Arrays visited before reaching parent of this node.
+   * These correspond to array indices in `path`.
+   * Note: ancestors includes arrays which contain the parent of visited node.
+   */
+  ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+) => any;
+
+/**
+ * A reducer is comprised of reducer functions which convert AST nodes into
+ * another form.
+ */
+type ASTReducer<R> = {
+  readonly [NodeT in ASTNode as NodeT['kind']]?: {
+    readonly enter?: ASTVisitFn<NodeT>;
+    readonly leave: ASTReducerFn<NodeT, R>;
+  };
+};
+
+const DocumentKeys: {
+  [NodeT in ASTNode as NodeT['kind']]: ReadonlyArray<keyof NodeT>;
+} = {
+  Name: [],
+
+  Document: ['definitions'],
+  OperationDefinition: [
+    'name',
+    'variableDefinitions',
+    'directives',
+    'selectionSet',
+  ],
+  VariableDefinition: ['variable', 'type', 'defaultValue', 'directives'],
+  Variable: ['name'],
+  SelectionSet: ['selections'],
+  Field: [
+    'alias',
+    'name',
+    'arguments',
+    'directives',
+    'selectionSet',
+    // Note: Client Controlled Nullability is experimental and may be changed
+    // or removed in the future.
+    'nullabilityAssertion',
+  ],
+  Argument: ['name', 'value'],
+  // Note: Client Controlled Nullability is experimental and may be changed
+  // or removed in the future.
+  ListNullabilityOperator: ['nullabilityAssertion'],
+  NonNullAssertion: ['nullabilityAssertion'],
+  ErrorBoundary: ['nullabilityAssertion'],
+
+  FragmentSpread: ['name', 'directives'],
+  InlineFragment: ['typeCondition', 'directives', 'selectionSet'],
+  FragmentDefinition: [
+    'name',
+    // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+    'variableDefinitions',
+    'typeCondition',
+    'directives',
+    'selectionSet',
+  ],
+
+  IntValue: [],
+  FloatValue: [],
+  StringValue: [],
+  BooleanValue: [],
+  NullValue: [],
+  EnumValue: [],
+  ListValue: ['values'],
+  ObjectValue: ['fields'],
+  ObjectField: ['name', 'value'],
+
+  Directive: ['name', 'arguments'],
+
+  NamedType: ['name'],
+  ListType: ['type'],
+  NonNullType: ['type'],
+
+  SchemaDefinition: ['description', 'directives', 'operationTypes'],
+  OperationTypeDefinition: ['type'],
+
+  ScalarTypeDefinition: ['description', 'name', 'directives'],
+  ObjectTypeDefinition: [
+    'description',
+    'name',
+    'interfaces',
+    'directives',
+    'fields',
+  ],
+  FieldDefinition: ['description', 'name', 'arguments', 'type', 'directives'],
+  InputValueDefinition: [
+    'description',
+    'name',
+    'type',
+    'defaultValue',
+    'directives',
+  ],
+  InterfaceTypeDefinition: [
+    'description',
+    'name',
+    'interfaces',
+    'directives',
+    'fields',
+  ],
+  UnionTypeDefinition: ['description', 'name', 'directives', 'types'],
+  EnumTypeDefinition: ['description', 'name', 'directives', 'values'],
+  EnumValueDefinition: ['description', 'name', 'directives'],
+  InputObjectTypeDefinition: ['description', 'name', 'directives', 'fields'],
+
+  DirectiveDefinition: ['description', 'name', 'arguments', 'locations'],
+
+  SchemaExtension: ['directives', 'operationTypes'],
+
+  ScalarTypeExtension: ['name', 'directives'],
+  ObjectTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
+  InterfaceTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
+  UnionTypeExtension: ['name', 'directives', 'types'],
+  EnumTypeExtension: ['name', 'directives', 'values'],
+  InputObjectTypeExtension: ['name', 'directives', 'fields'],
+};
+
+/**
+ * Given a visitor instance and a node kind, return EnterLeaveVisitor for that kind.
+ */
+function getEnterLeaveForKind(
+  visitor: ASTVisitor,
+  kind: Kind,
+): EnterLeaveVisitor<ASTNode> {
+  const kindVisitor:
+    | ASTVisitFn<ASTNode>
+    | EnterLeaveVisitor<ASTNode>
+    | undefined = (visitor as any)[kind];
+
+  if (typeof kindVisitor === 'object') {
+    // { Kind: { enter() {}, leave() {} } }
+    return kindVisitor;
+  } else if (typeof kindVisitor === 'function') {
+    // { Kind() {} }
+    return { enter: kindVisitor, leave: undefined };
+  }
+
+  // { enter() {}, leave() {} }
+  return { enter: (visitor as any).enter, leave: (visitor as any).leave };
+}
+
+const kindValues = new Set<string>(Object.keys(DocumentKeys));
+
+function isNode(maybeNode: any): maybeNode is ASTNode {
+  const maybeKind = maybeNode?.kind;
+  return typeof maybeKind === 'string' && kindValues.has(maybeKind);
+}
+
+type ASTReducerFn<TReducedNode extends ASTNode, R> = (
+  /** The current node being visiting. */
+  node: { [K in keyof TReducedNode]: ReducedField<TReducedNode[K], R> },
+  /** The index or key to this node from the parent node or Array. */
+  key: string | number | undefined,
+  /** The parent immediately above this node, which may be an Array. */
+  parent: ASTNode | ReadonlyArray<ASTNode> | undefined,
+  /** The key path to get to this node from the root node. */
+  path: ReadonlyArray<string | number>,
+  /**
+   * All nodes and Arrays visited before reaching parent of this node.
+   * These correspond to array indices in `path`.
+   * Note: ancestors includes arrays which contain the parent of visited node.
+   */
+  ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+) => R;
+
+type ReducedField<T, R> = T extends ASTNode
+  ? R
+  : T extends ReadonlyArray<ASTNode>
+  ? ReadonlyArray<R>
+  : T;
+
+interface EnterLeaveVisitor<TVisitedNode extends ASTNode> {
+  readonly enter?: ASTVisitFn<TVisitedNode> | undefined;
+  readonly leave?: ASTVisitFn<TVisitedNode> | undefined;
+}
+
+/**
+ * A KeyMap describes each the traversable properties of each kind of node.
+ */
+type ASTVisitorKeyMap = {
+  [NodeT in ASTNode as NodeT['kind']]?: ReadonlyArray<keyof NodeT>;
+};
+
+export const BREAK: unknown = Object.freeze({});
+
+/**
+ * visit() will walk through an AST using a depth-first traversal, calling
+ * the visitor's enter function at each node in the traversal, and calling the
+ * leave function after visiting that node and all of its child nodes.
+ *
+ * NOTE: this version of visit has been modified from the upstream version
+ * in graphql-js so that it memoizes arrays within the AST. Memoization can
+ * also be added to individual nodes by passing memoizing visitor functions.
+ *
+ * By returning different values from the enter and leave functions, the
+ * behavior of the visitor can be altered, including skipping over a sub-tree of
+ * the AST (by returning false), editing the AST by returning a value or null
+ * to remove the value, or to stop the whole traversal by returning BREAK.
+ *
+ * When using visit() to edit an AST, the original AST will not be modified, and
+ * a new version of the AST with the changes applied will be returned from the
+ * visit function.
+ *
+ * ```ts
+ * const editedAST = visit(ast, {
+ *   enter(node) {
+ *     // @return
+ *     //   undefined: no action
+ *     //   false: skip visiting this node
+ *     //   BREAK: stop visiting altogether
+ *     //   null: delete this node
+ *     //   any value: replace this node with the returned value
+ *   },
+ *   leave(node) {
+ *     // @return
+ *     //   undefined: no action
+ *     //   false: no action
+ *     //   BREAK: stop visiting altogether
+ *     //   null: delete this node
+ *     //   any value: replace this node with the returned value
+ *   }
+ * });
+ * ```
+ *
+ * Alternatively to providing enter() and leave() functions, a visitor can
+ * instead provide functions named the same as the kinds of AST nodes, or
+ * enter/leave visitors at a named key, leading to three permutations of the
+ * visitor API:
+ *
+ * 1) Named visitors triggered when entering a node of a specific kind.
+ *
+ * ```ts
+ * visitWithMemo(ast, {
+ *   Kind(node) {
+ *     // enter the "Kind" node
+ *   }
+ * })
+ * ```
+ *
+ * 2) Named visitors that trigger upon entering and leaving a node of a specific kind.
+ *
+ * ```ts
+ * visitWithMemo(ast, {
+ *   Kind: {
+ *     enter(node) {
+ *       // enter the "Kind" node
+ *     }
+ *     leave(node) {
+ *       // leave the "Kind" node
+ *     }
+ *   }
+ * })
+ * ```
+ *
+ * 3) Generic visitors that trigger upon entering and leaving any node.
+ *
+ * ```ts
+ * visitWithMemo(ast, {
+ *   enter(node) {
+ *     // enter any node
+ *   },
+ *   leave(node) {
+ *     // leave any node
+ *   }
+ * })
+ * ```
+ */
+export function visitWithMemo<N extends ASTNode>(
+  root: N,
+  visitor: ASTVisitor,
+  visitorKeys?: ASTVisitorKeyMap,
+): N;
+export function visitWithMemo<R>(
+  root: ASTNode,
+  visitor: ASTReducer<R>,
+  visitorKeys?: ASTVisitorKeyMap,
+): R;
+export function visitWithMemo(
+  root: ASTNode,
+  visitor: ASTVisitor | ASTReducer<any>,
+  visitorKeys: ASTVisitorKeyMap = DocumentKeys,
+): any {
+  const enterLeaveMap = new Map<Kind, EnterLeaveVisitor<ASTNode>>();
+  for (const kind of Object.values(Kind)) {
+    enterLeaveMap.set(kind, getEnterLeaveForKind(visitor, kind));
+  }
+
+  /* eslint-disable no-undef-init */
+  let stack: any = undefined;
+  let inArray = Array.isArray(root);
+  let keys: any = [root];
+  let index = -1;
+  let edits = new Map<string | number, any>();
+  let node: any = root;
+  let key: any = undefined;
+  let parent: any = undefined;
+  const path: any = [];
+  const ancestors = [];
+  /* eslint-enable no-undef-init */
+
+  do {
+    index++;
+    const isLeaving = index === keys.length;
+    const isEdited = isLeaving && edits.size !== 0;
+    if (isLeaving) {
+      key = ancestors.length === 0 ? undefined : path[path.length - 1];
+      node = parent;
+      parent = ancestors.pop();
+      if (isEdited) {
+        if (inArray) {
+          let arr: Array<any> = emptyArray;
+          for (let arrIndex = 0; arrIndex < node.length; arrIndex++) {
+            const editValue = edits.get(arrIndex);
+            if (editValue === undefined) {
+              arr = appendToArray(arr, node[arrIndex]);
+            } else if (editValue !== null) {
+              arr = appendToArray(arr, editValue);
+            }
+          }
+          node = arr;
+        } else {
+          let newNode = node;
+          for (const [editKey, editValue] of edits) {
+            newNode = updateNode(newNode, editKey as string, editValue);
+          }
+          node = newNode;
+        }
+      }
+      index = stack.index;
+      keys = stack.keys;
+      edits = stack.edits;
+      inArray = stack.inArray;
+      stack = stack.prev;
+    } else if (parent != null) {
+      key = inArray ? index : keys[index];
+      node = parent[key];
+      if (node === null || node === undefined) {
+        continue;
+      }
+      path.push(key);
+    }
+
+    let result;
+    if (!Array.isArray(node)) {
+      const visitFn = isLeaving
+        ? enterLeaveMap.get(node.kind)?.leave
+        : enterLeaveMap.get(node.kind)?.enter;
+
+      result = visitFn?.call(visitor, node, key, parent, path, ancestors);
+
+      if (result === BREAK) {
+        break;
+      }
+
+      if (result === false) {
+        path.pop();
+        continue;
+      } else if (result !== undefined) {
+        edits.set(key, result);
+        if (!isLeaving) {
+          if (isNode(result)) {
+            node = result;
+          } else {
+            path.pop();
+            continue;
+          }
+        }
+      }
+    }
+
+    if (result === undefined && isEdited) {
+      edits.set(key, node);
+    }
+
+    if (isLeaving) {
+      path.pop();
+    } else {
+      stack = { inArray, index, keys, edits, prev: stack };
+      inArray = Array.isArray(node);
+      keys = inArray ? node : (visitorKeys as any)[node.kind] ?? [];
+      index = -1;
+      edits = new Map();
+      if (parent != null) {
+        ancestors.push(parent);
+      }
+      parent = node;
+    }
+  } while (stack !== undefined);
+
+  if (edits.size !== 0) {
+    // New root
+    return Array.from(edits.values()).at(-1);
+  }
+
+  return root;
+}


### PR DESCRIPTION
what selections are included will affect the plan, so we need to eval plans in that context.

in order to preserve performance, we can introduce some memoization so that plan creation is memoized.

= we memoize (for now) inlineRootFragments and also memoize plan creation

= we may need to rework the exact memoization mechanics