### PR TITLE
pass through simple SuperSchema helpers

### DIFF
--- a/src/stitch/SubFieldPlan.ts
+++ b/src/stitch/SubFieldPlan.ts
@@ -52,10 +52,7 @@ export class SubFieldPlan {
 
     let possibleTypes: ReadonlyArray<GraphQLObjectType>;
     if (isAbstractType(parentType)) {
-      possibleTypes =
-        this.operationContext.superSchema.mergedSchema.getPossibleTypes(
-          parentType,
-        );
+      possibleTypes = this.superSchema.getPossibleTypes(parentType);
     } else {
       possibleTypes = [parentType];
     }


### PR DESCRIPTION
instead of rewriting