### PR TITLE
compose: refactor

### DIFF
--- a/src/stitch/Composer.ts
+++ b/src/stitch/Composer.ts
@@ -1,9 +1,4 @@
-import type {
-  DocumentNode,
-  ExecutionResult,
-  FieldNode,
-  SelectionNode,
-} from 'graphql';
+import type { DocumentNode, ExecutionResult, SelectionNode } from 'graphql';
 import { GraphQLError, isObjectType, Kind, OperationTypeNode } from 'graphql';
 
 import type { ObjMap } from '../types/ObjMap.js';
@@ -16,30 +11,30 @@ import { inspect } from '../utilities/inspect.js';
 import { invariant } from '../utilities/invariant.js';
 import { PromiseAggregator } from '../utilities/PromiseAggregator.js';
 
-import type { StitchPlan } from './Planner.js';
+import type { StitchPlan, SubschemaPlan } from './Planner.js';
 import type { Subschema, SuperSchema } from './SuperSchema.js';
 
-type Path = ReadonlyArray<string | number>;
-
-export interface Stitch {
-  fromSubschema: Subschema;
-  stitchPlans: ObjMap<StitchPlan> | undefined;
+export interface SubschemaPlanResult {
+  subschemaPlan: SubschemaPlan;
   initialResult: PromiseOrValue<ExecutionResult>;
 }
 
-interface FetchPlan {
-  fieldNodes: ReadonlyArray<FieldNode>;
-  stitchPlans: ObjMap<StitchPlan> | undefined;
+interface Pointer {
   parent: ObjMap<unknown>;
+  responseKey: string | number;
+}
+
+interface Stitch {
+  subschemaPlan: SubschemaPlan;
   target: ObjMap<unknown>;
-  path: Path;
+  pointer: Pointer | undefined;
 }
 
 /**
  * @internal
  */
 export class Composer {
-  stitches: Array<Stitch>;
+  subschemaPlanResults: Array<SubschemaPlanResult>;
   superSchema: SuperSchema;
   rawVariableValues:
     | {
@@ -53,7 +48,7 @@ export class Composer {
   promiseAggregator: PromiseAggregator;
 
   constructor(
-    stitches: Array<Stitch>,
+    subschemaPlanResults: Array<SubschemaPlanResult>,
     superSchema: SuperSchema,
     rawVariableValues:
       | {
@@ -61,7 +56,7 @@ export class Composer {
         }
       | undefined,
   ) {
-    this.stitches = stitches;
+    this.subschemaPlanResults = subschemaPlanResults;
     this.superSchema = superSchema;
     this.rawVariableValues = rawVariableValues;
     this.fields = Object.create(null);
@@ -71,8 +66,14 @@ export class Composer {
   }
 
   compose(): PromiseOrValue<ExecutionResult> {
-    for (const stitch of this.stitches) {
-      this._handleMaybeAsyncResult(undefined, this.fields, stitch, []);
+    for (const subschemaPlanResult of this.subschemaPlanResults) {
+      const { subschemaPlan, initialResult } = subschemaPlanResult;
+      this._handleMaybeAsyncResult(
+        undefined,
+        this.fields,
+        subschemaPlan,
+        initialResult,
+      );
     }
 
     if (this.promiseAggregator.isEmpty()) {
@@ -107,49 +108,41 @@ export class Composer {
   }
 
   _handleMaybeAsyncResult(
-    parent: ObjMap<unknown> | undefined,
+    pointer: Pointer | undefined,
     fields: ObjMap<unknown>,
-    stitch: Stitch,
-    path: Path,
+    subschemaPlan: SubschemaPlan,
+    initialResult: PromiseOrValue<ExecutionResult>,
   ): void {
-    const initialResult = stitch.initialResult;
     if (!isPromise(initialResult)) {
-      this._handleResult(parent, fields, stitch, initialResult, path);
+      this._handleResult(pointer, fields, subschemaPlan, initialResult);
       return;
     }
 
     const promise = initialResult.then(
-      (resolved) => this._handleResult(parent, fields, stitch, resolved, path),
+      (resolved) =>
+        this._handleResult(pointer, fields, subschemaPlan, resolved),
       (err) =>
-        this._handleResult(
-          parent,
-          fields,
-          stitch,
-          {
-            data: null,
-            errors: [new GraphQLError(err.message, { originalError: err })],
-          },
-          path,
-        ),
+        this._handleResult(pointer, fields, subschemaPlan, {
+          data: null,
+          errors: [new GraphQLError(err.message, { originalError: err })],
+        }),
     );
 
     this.promiseAggregator.add(promise);
   }
 
   _handleResult(
-    parent: ObjMap<unknown> | undefined,
+    pointer: Pointer | undefined,
     fields: ObjMap<unknown>,
-    stitch: Stitch | undefined,
+    subschemaPlan: SubschemaPlan,
     result: ExecutionResult,
-    path: Path,
   ): void {
     if (result.errors != null) {
       this.errors.push(...result.errors);
     }
 
-    const parentKey: string | number | undefined = path[path.length - 1];
-    if (parent !== undefined) {
-      if (parent[parentKey] === null) {
+    if (pointer !== undefined) {
+      if (pointer.parent[pointer.responseKey] === null) {
         return;
       }
     } else if (this.nulled) {
@@ -157,10 +150,10 @@ export class Composer {
     }
 
     if (result.data == null) {
-      if (parentKey === undefined) {
+      if (pointer === undefined) {
         this.nulled = true;
-      } else if (parent) {
-        parent[parentKey] = null;
+      } else {
+        pointer.parent[pointer.responseKey] = null;
         // TODO: null bubbling?
       }
       return;
@@ -170,67 +163,66 @@ export class Composer {
       fields[key] = value;
     }
 
-    if (stitch?.stitchPlans !== undefined) {
-      const subFetchMap = new AccumulatorMap<Subschema, FetchPlan>();
-      this._walkStitchPlans(subFetchMap, result.data, stitch.stitchPlans, path);
-      for (const [subschema, subFetches] of subFetchMap) {
-        for (const subFetch of subFetches) {
-          // TODO: batch subStitches by accessors
-          // TODO: batch subStitches by subschema?
-          const subStitch: Stitch = {
-            fromSubschema: subschema,
-            stitchPlans: subFetch.stitchPlans,
-            initialResult: subschema.executor({
-              document: this._createDocument(subFetch.fieldNodes),
-              variables: this.rawVariableValues,
-            }),
-          };
-
-          this._handleMaybeAsyncResult(
-            subFetch.parent,
-            subFetch.target,
-            subStitch,
-            subFetch.path,
-          );
-        }
-      }
+    if (subschemaPlan.stitchPlans !== undefined) {
+      const stitchMap = new AccumulatorMap<Subschema, Stitch>();
+      this._walkStitchPlans(stitchMap, result.data, subschemaPlan.stitchPlans);
+      this._performStitches(stitchMap);
     }
   }
 
   _walkStitchPlans(
-    subFetchMap: AccumulatorMap<Subschema, FetchPlan>,
+    stitchMap: AccumulatorMap<Subschema, Stitch>,
     fields: ObjMap<unknown>,
     stitchPlans: ObjMap<StitchPlan>,
-    path: Path,
   ): void {
     for (const [key, stitchPlan] of Object.entries(stitchPlans)) {
       if (fields[key] !== undefined) {
         this._collectSubFetches(
-          subFetchMap,
+          stitchMap,
           fields,
+          key,
           fields[key] as ObjMap<unknown> | Array<unknown>,
           stitchPlan,
-          [...path, key],
+        );
+      }
+    }
+  }
+
+  _performStitches(stitchMap: Map<Subschema, ReadonlyArray<Stitch>>): void {
+    for (const [subschema, stitches] of stitchMap) {
+      for (const stitch of stitches) {
+        // TODO: batch subStitches by accessors
+        // TODO: batch subStitches by subschema?
+        const subschemaPlan = stitch.subschemaPlan;
+        const initialResult = subschema.executor({
+          document: this._createDocument(stitch.subschemaPlan.fieldNodes),
+          variables: this.rawVariableValues,
+        });
+        this._handleMaybeAsyncResult(
+          stitch.pointer,
+          stitch.target,
+          subschemaPlan,
+          initialResult,
         );
       }
     }
   }
 
   _collectSubFetches(
-    subFetchMap: AccumulatorMap<Subschema, FetchPlan>,
+    stitchMap: AccumulatorMap<Subschema, Stitch>,
     parent: ObjMap<unknown> | Array<unknown>,
+    responseKey: string | number,
     fieldsOrList: ObjMap<unknown> | Array<unknown>,
     stitchPlan: StitchPlan,
-    path: Path,
   ): void {
     if (Array.isArray(fieldsOrList)) {
       for (let i = 0; i < fieldsOrList.length; i++) {
         this._collectSubFetches(
-          subFetchMap,
+          stitchMap,
           fieldsOrList,
+          i,
           fieldsOrList[i] as ObjMap<unknown>,
           stitchPlan,
-          [...path, i],
         );
       }
       return;
@@ -262,21 +254,17 @@ export class Composer {
       `Missing field plan for type '${typeName}'.`,
     );
 
-    for (const [subschema, subschemaPlan] of fieldPlan.subschemaPlans) {
-      subFetchMap.add(subschema, {
-        fieldNodes: subschemaPlan.fieldNodes,
-        stitchPlans: subschemaPlan.stitchPlans,
-        parent: parent as ObjMap<unknown>,
+    for (const subschemaPlan of fieldPlan.subschemaPlans) {
+      stitchMap.add(subschemaPlan.toSubschema, {
+        subschemaPlan,
+        pointer: {
+          parent: parent as ObjMap<unknown>,
+          responseKey,
+        },
         target: fieldsOrList,
-        path,
       });
     }
 
-    this._walkStitchPlans(
-      subFetchMap,
-      fieldsOrList,
-      fieldPlan.stitchPlans,
-      path,
-    );
+    this._walkStitchPlans(stitchMap, fieldsOrList, fieldPlan.stitchPlans);
   }
 }

--- a/src/stitch/__tests__/Composer-test.ts
+++ b/src/stitch/__tests__/Composer-test.ts
@@ -18,7 +18,7 @@ import { describe, it } from 'mocha';
 
 import { invariant } from '../../utilities/invariant.js';
 
-import type { Stitch } from '../Composer.js';
+import type { SubschemaPlanResult } from '../Composer.js';
 import { Composer } from '../Composer.js';
 import { Planner } from '../Planner.js';
 import type { Subschema } from '../SuperSchema.js';
@@ -48,9 +48,9 @@ function executeWithComposer(
 
   invariant(!(fieldPlan instanceof GraphQLError));
 
-  const stitches: Array<Stitch> = [];
+  const subschemaPlanResults: Array<SubschemaPlanResult> = [];
 
-  for (const [subschema, subschemaPlan] of fieldPlan.subschemaPlans) {
+  for (const subschemaPlan of fieldPlan.subschemaPlans) {
     const document: DocumentNode = {
       kind: Kind.DOCUMENT,
       definitions: [
@@ -64,16 +64,19 @@ function executeWithComposer(
       ],
     };
 
-    stitches.push({
-      fromSubschema: subschema,
-      stitchPlans: subschemaPlan.stitchPlans,
-      initialResult: subschema.executor({
+    subschemaPlanResults.push({
+      subschemaPlan,
+      initialResult: subschemaPlan.toSubschema.executor({
         document,
       }),
     });
   }
 
-  const composer = new Composer(stitches, fieldPlan.superSchema, undefined);
+  const composer = new Composer(
+    subschemaPlanResults,
+    fieldPlan.superSchema,
+    undefined,
+  );
 
   return composer.compose();
 }

--- a/src/stitch/printPlan.ts
+++ b/src/stitch/printPlan.ts
@@ -2,7 +2,7 @@ import type { FieldNode, GraphQLObjectType, SelectionSetNode } from 'graphql';
 import { Kind, print } from 'graphql';
 
 import type { FieldPlan, StitchPlan, SubschemaPlan } from './Planner.js';
-import type { Subschema, SuperSchema } from './SuperSchema.js';
+import type { SuperSchema } from './SuperSchema.js';
 
 function generateIndent(indent: number): string {
   return ' '.repeat(indent);
@@ -16,14 +16,14 @@ export function printPlan(
   const superSchema = plan.superSchema;
   const entries = [];
   const stitchPlans = Object.entries(plan.stitchPlans);
-  if (plan.subschemaPlans.size > 0 || stitchPlans.length > 0) {
+  if (plan.subschemaPlans.length > 0 || stitchPlans.length > 0) {
     const spaces = generateIndent(indent);
 
     entries.push(
       `${spaces}${type === undefined ? 'Plan' : `For type '${type.name}'`}:`,
     );
 
-    if (plan.subschemaPlans.size > 0) {
+    if (plan.subschemaPlans.length > 0) {
       entries.push(
         printSubschemaPlans(superSchema, plan.subschemaPlans, indent + 2),
       );
@@ -38,19 +38,18 @@ export function printPlan(
 
 function printSubschemaPlans(
   superSchema: SuperSchema,
-  subschemaPlans: Map<Subschema, SubschemaPlan>,
+  subschemaPlans: ReadonlyArray<SubschemaPlan>,
   indent: number,
 ): string {
-  return [...subschemaPlans.entries()]
-    .map(([subschema, subschemaPlan]) =>
-      printSubschemaPlan(superSchema, subschema, subschemaPlan, indent),
+  return subschemaPlans
+    .map((subschemaPlan) =>
+      printSubschemaPlan(superSchema, subschemaPlan, indent),
     )
     .join('\n');
 }
 
 function printSubschemaPlan(
   superSchema: SuperSchema,
-  subschema: Subschema,
   subschemaPlan: SubschemaPlan,
   indent: number,
 ): string {
@@ -60,7 +59,9 @@ function printSubschemaPlan(
   const stitchPlans = Object.entries(subschemaPlan.stitchPlans);
   if (subschemaPlan.fieldNodes.length > 0 || stitchPlans.length > 0) {
     entries.push(
-      `${spaces}For Subschema: [${superSchema.getSubschemaId(subschema)}]`,
+      `${spaces}For Subschema: [${superSchema.getSubschemaId(
+        subschemaPlan.toSubschema,
+      )}]`,
     );
   }
 

--- a/src/stitch/subscribe.ts
+++ b/src/stitch/subscribe.ts
@@ -35,8 +35,8 @@ export function subscribe(
     return { errors: [rootFieldPlan] };
   }
 
-  const iteration = rootFieldPlan.subschemaPlans.entries().next();
-  if (iteration.done) {
+  const subschemaPlan = rootFieldPlan.subschemaPlans[0];
+  if (subschemaPlan === undefined) {
     const error = new GraphQLError('Could not route subscription.', {
       nodes: operation,
     });
@@ -44,8 +44,7 @@ export function subscribe(
     return { errors: [error] };
   }
 
-  const [subschema, subschemaPlan] = iteration.value;
-
+  const subschema = subschemaPlan.toSubschema;
   const subscriber = subschema.subscriber;
   if (!subscriber) {
     const error = new GraphQLError(
@@ -81,8 +80,7 @@ export function subscribe(
           const composer = new Composer(
             [
               {
-                fromSubschema: subschema,
-                stitchPlans: subschemaPlan.stitchPlans,
+                subschemaPlan,
                 initialResult: payload,
               },
             ],
@@ -102,8 +100,7 @@ export function subscribe(
       const composer = new Composer(
         [
           {
-            fromSubschema: subschema,
-            stitchPlans: subschemaPlan.stitchPlans,
+            subschemaPlan,
             initialResult: payload,
           },
         ],


### PR DESCRIPTION
= after build, subschemaPlans can be an array, not a map

= paths not necessary, only final pointer needed; full path might be necessary later for null bubbling = rename Stitch to SubschemaPlanResult

= rename FetchPlan type to Stitch => it is what reads from a StitchPlan