### PR TITLE
filter out stitching meta values

### DIFF
--- a/src/stitch/__tests__/compose-test.ts
+++ b/src/stitch/__tests__/compose-test.ts
@@ -177,7 +177,6 @@ describe('Composer', () => {
       expect(result).to.deep.equal({
         data: {
           someObject: {
-            __stitching__typename: 'SomeObject',
             someField: 'someField',
             anotherField: 'anotherField',
           },
@@ -233,9 +232,7 @@ describe('Composer', () => {
       expect(result).to.deep.equal({
         data: {
           someObject: {
-            __stitching__typename: 'SomeObject',
             someField: {
-              __stitching__typename: 'SomeNestedObject',
               someNestedField: 'someNestedField',
               anotherNestedField: 'anotherNestedField',
             },
@@ -341,12 +338,10 @@ describe('Composer', () => {
         data: {
           someObject: [
             {
-              __stitching__typename: 'SomeObject',
               someField: ['someFieldA'],
               anotherField: ['anotherField'],
             },
             {
-              __stitching__typename: 'SomeObject',
               someField: ['someFieldB'],
               anotherField: ['anotherField'],
             },
@@ -388,14 +383,12 @@ describe('Composer', () => {
       const someSubschema = getSubschema(someSchema, {
         someObject: [
           {
-            __stitching__typename: 'SomeObject',
             someField: [
               { someNestedField: ['someNestedFieldA'] },
               { someNestedField: ['someNestedFieldB'] },
             ],
           },
           {
-            __stitching__typename: 'SomeObject',
             someField: [
               { someNestedField: ['someNestedField1'] },
               { someNestedField: ['someNestedField2'] },
@@ -419,30 +412,24 @@ describe('Composer', () => {
         data: {
           someObject: [
             {
-              __stitching__typename: 'SomeObject',
               someField: [
                 {
-                  __stitching__typename: 'SomeNestedObject',
                   someNestedField: ['someNestedFieldA'],
                   anotherNestedField: ['anotherNestedField'],
                 },
                 {
-                  __stitching__typename: 'SomeNestedObject',
                   someNestedField: ['someNestedFieldB'],
                   anotherNestedField: ['anotherNestedField'],
                 },
               ],
             },
             {
-              __stitching__typename: 'SomeObject',
               someField: [
                 {
-                  __stitching__typename: 'SomeNestedObject',
                   someNestedField: ['someNestedField1'],
                   anotherNestedField: ['anotherNestedField'],
                 },
                 {
-                  __stitching__typename: 'SomeNestedObject',
                   someNestedField: ['someNestedField2'],
                   anotherNestedField: ['anotherNestedField'],
                 },


### PR DESCRIPTION
e.g.: `__stitching__typename`

= an initially returned result will not return a stitching metafield at the root because nothing is ever "stitched," those fields are all copied in parallel
= a subsequently returned field will not return a stitching metafield at the root because it would have already been requested in the initial operation

so to filter, we just have to "recopy" all the non stitching meta fields as we perform the stitch.

what we could do instead is mutate the returned result by deleting the stitching meta field or by simply setting it to null.